### PR TITLE
Add create dataset command to the agent

### DIFF
--- a/cmd/dataset/create.go
+++ b/cmd/dataset/create.go
@@ -1,0 +1,54 @@
+package dataset
+
+import (
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/pennsieve/pennsieve-agent/pkg/config"
+	"github.com/pennsieve/pennsieve-agent/pkg/store"
+	"github.com/pennsieve/pennsieve-go/pkg/pennsieve/models/dataset"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// CreateCmd creates a new dataset.
+var CreateCmd = &cobra.Command{
+	Use:   "create '<name>' '<description>' '[\"<tag1>\", \"<tag2>\", ...]'",
+	Short: "Create a new dataset.",
+	Long:  `Create a new dataset within a users organization`,
+	Args:  cobra.MinimumNArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+
+		name := args[0]
+		description := args[1]
+		tags := args[2]
+
+		db, _ := config.InitializeDB()
+		userSettingsStore := store.NewUserSettingsStore(db)
+		userInfoStore := store.NewUserInfoStore(db)
+		pennsieveClient, err := config.InitPennsieveClient(userSettingsStore, userInfoStore)
+		if err != nil {
+			log.Fatalln("Cannot connect to Pennsieve.")
+		}
+
+		response, err := pennsieveClient.Dataset.Create(nil, name, description, tags)
+		if err != nil {
+			log.Error(err)
+		}
+		PrettyPrintCreate(response)
+	},
+}
+
+func PrettyPrintCreate(ds *dataset.CreateDatasetResponse) {
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.SetTitle("New dataset created")
+	t.AppendRows([]table.Row{
+		{"NAME", ds.Content.Name},
+		{"INT ID", ds.Content.IntID},
+		{"NODE ID", ds.Content.ID},
+		{"ORGANIZATION", ds.Organization},
+		{"Description", ds.Content.Description},
+	})
+
+	t.Render()
+}

--- a/cmd/dataset/dataset.go
+++ b/cmd/dataset/dataset.go
@@ -52,6 +52,7 @@ func init() {
 	DatasetCmd.AddCommand(UseCmd)
 	DatasetCmd.AddCommand(ListCmd)
 	DatasetCmd.AddCommand(FindCmd)
+	DatasetCmd.AddCommand(CreateCmd)
 
 	DatasetCmd.Flags().BoolP("full", "f",
 		false, "Show expanded information")

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/jedib0t/go-pretty/v6 v6.3.0
 	github.com/mattn/go-sqlite3 v1.14.12
-	github.com/pennsieve/pennsieve-go v1.2.1
+	github.com/pennsieve/pennsieve-go v1.2.2
 	github.com/pennsieve/pennsieve-go-api v1.3.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pennsieve/pennsieve-go v1.2.1 h1:9fytVm+B6DBnUraGACZHmIUtJ2OkVIJrl3vSqgoie1M=
-github.com/pennsieve/pennsieve-go v1.2.1/go.mod h1:9V1bnE2Rv4y0u3oiKSaSeULqqxW7Ta7sXwUp99zxlKc=
+github.com/pennsieve/pennsieve-go v1.2.2 h1:qwXlrBtwkiolSH/P7dO1qMTS93NRGUz9dddSRSHXfTM=
+github.com/pennsieve/pennsieve-go v1.2.2/go.mod h1:9V1bnE2Rv4y0u3oiKSaSeULqqxW7Ta7sXwUp99zxlKc=
 github.com/pennsieve/pennsieve-go-api v1.3.1 h1:CJkZF+FDVdSg0CX/mhv/3HUrqjdL/AyNvsXL3JJub48=
 github.com/pennsieve/pennsieve-go-api v1.3.1/go.mod h1:kW7JQkTJ+7zwBco5jOnDFWfHx0RDBeGgaPh40+75G9g=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Add a command line option to create datasets from the command line.

Works like:

`pennsieve dataset create 'DATASET_NAME' 'DATASET_DESCRIPTION '["tag1", "tag2", ...]'`

If not tags are available an empty list `[]` can be accepted