### PR TITLE
Use semantic versioning for "test" tags

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ name: Publish-Release
 on:
   push:
     tags:
-      - 'test.*'
+      - '*-test'
       - '*.*.*'  # Match anything resembling semver
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Download the latest installer for your operating system: https://github.com/Penn
 ## Releasing a new version
 
 1. Merge updates into the main branch
-2. Create a new tag in main and name the tag: vx.x.x following [semantic versioning](https://semver.org/).
+2. Create a new tag in main and name the tag: x.x.x following [semantic versioning](https://semver.org/).
 
     e.g ```git tag -a 0.0.1 -m "Initial release"```
 


### PR DESCRIPTION
PR changes the Publish-Release job to match on tags with `-test` as a suffix instead of `test-`as a prefix. This better conforms to semantic versioning. And should also satisfy `dpkg` which requires version names to start with a digit.