### PR TITLE
Feature/update nix post install scripts

### DIFF
--- a/ci/unix/linux_post_install.sh
+++ b/ci/unix/linux_post_install.sh
@@ -64,7 +64,12 @@ chmod 755 "$PS_PATH"
 #	mkdir "$PS_HOME/cache"
 #fi
 
-# Symlink $PS_EXECUTABLE to /usr/local/bin:
-if [ -d "/usr/local/bin" ]; then
-  sudo ln -s -f "$PS_EXECUTABLE" "/usr/local/bin/pennsieve"
+# Create /usr/local/bin if it does not exist
+if [ ! -d "/usr/local/bin" ]; then
+	mkdir /usr/local/bin
+	sudo chmod 755 /usr/local/bin
 fi
+
+
+# Symlink $PS_EXECUTABLE to /usr/local/bin:
+sudo ln -s -f "$PS_EXECUTABLE" "/usr/local/bin/pennsieve"

--- a/ci/unix/linux_post_install.sh
+++ b/ci/unix/linux_post_install.sh
@@ -66,7 +66,7 @@ chmod 755 "$PS_PATH"
 
 # Create /usr/local/bin if it does not exist
 if [ ! -d "/usr/local/bin" ]; then
-	mkdir /usr/local/bin
+	sudo mkdir /usr/local/bin
 	sudo chmod 755 /usr/local/bin
 fi
 

--- a/ci/unix/linux_post_install.sh
+++ b/ci/unix/linux_post_install.sh
@@ -34,6 +34,7 @@
 PS_HOME="$HOME/.pennsieve"
 PS_PATH="<%= ps_path %>"
 PS_EXECUTABLE="<%= ps_executable %>"
+USER_BINARY_DIR="/usr/local/bin"
 
 # Create the Pennsieve home directory, if needed:
 if [ ! -d "$PS_HOME" ]; then
@@ -65,11 +66,25 @@ chmod 755 "$PS_PATH"
 #fi
 
 # Create /usr/local/bin if it does not exist
-if [ ! -d "/usr/local/bin" ]; then
-	sudo mkdir /usr/local/bin
-	sudo chmod 755 /usr/local/bin
+if [ ! -d $USER_BINARY_DIR ]; then
+
+	sudo mkdir $USER_BINARY_DIR
+	mkdir_status=$?
+	if [ "$mkdir_status" -ne 0 ]; then
+	  echo "Failed to create $USER_BINARY_DIR" >> $INSTALL_LOG
+	fi
+
+	sudo chmod 755 $USER_BINARY_DIR
+  chmod_status=$?
+  if [ "$chmod_status" -ne 0 ]; then
+    echo "Failed to update permissions on $USER_BINARY_DIR" >> $INSTALL_LOG
+  fi
 fi
 
 
 # Symlink $PS_EXECUTABLE to /usr/local/bin:
-sudo ln -s -f "$PS_EXECUTABLE" "/usr/local/bin/pennsieve"
+sudo ln -s -f "$PS_EXECUTABLE" "$USER_BINARY_DIR/pennsieve"
+ln_status=$?
+if [ "$ln_status" -ne 0 ]; then
+  echo "Failed to create symlink from $PS_EXECUTABLE to $USER_BINARY_DIR/pennsieve" >> $INSTALL_LOG
+fi

--- a/ci/unix/mac_post_install.sh
+++ b/ci/unix/mac_post_install.sh
@@ -34,6 +34,7 @@
 PS_HOME="$HOME/.pennsieve"
 PS_PATH="<%= ps_path %>"
 PS_EXECUTABLE="<%= ps_executable %>"
+USER_BINARY_DIR="/usr/local/bin"
 
 # Create the Pennsieve home directory, if needed:
 if [ ! -d "$PS_HOME" ]; then
@@ -66,11 +67,26 @@ sudo chgrp -R staff "$PS_PATH"
 #fi
 
 # Create /usr/local/bin if it does not exist
-if [ ! -d "/usr/local/bin" ]; then
-	sudo mkdir /usr/local/bin
-	sudo chmod 755 /usr/local/bin
+if [ ! -d $USER_BINARY_DIR ]; then
+
+	sudo mkdir $USER_BINARY_DIR
+	mkdir_status=$?
+	if [ "$mkdir_status" -ne 0 ]; then
+	  echo "Failed to create $USER_BINARY_DIR" >> $INSTALL_LOG
+	fi
+
+	sudo chmod 755 $USER_BINARY_DIR
+  chmod_status=$?
+  if [ "$chmod_status" -ne 0 ]; then
+    echo "Failed to update permissions on $USER_BINARY_DIR" >> $INSTALL_LOG
+  fi
 fi
 
 
 # Symlink $PS_EXECUTABLE to /usr/local/bin:
-sudo ln -s -f "$PS_EXECUTABLE" "/usr/local/bin/pennsieve"
+sudo ln -s -f "$PS_EXECUTABLE" "$USER_BINARY_DIR/pennsieve"
+ln_status=$?
+if [ "$ln_status" -ne 0 ]; then
+  echo "Failed to create symlink from $PS_EXECUTABLE to $USER_BINARY_DIR/pennsieve" >> $INSTALL_LOG
+fi
+

--- a/ci/unix/mac_post_install.sh
+++ b/ci/unix/mac_post_install.sh
@@ -65,7 +65,12 @@ sudo chgrp -R staff "$PS_PATH"
 #	mkdir "$PS_HOME/cache"
 #fi
 
-# Symlink $PS_EXECUTABLE to /usr/local/bin:
-if [ -d "/usr/local/bin" ]; then
-  sudo ln -s -f "$PS_EXECUTABLE" "/usr/local/bin/pennsieve"
+# Create /usr/local/bin if it does not exist
+if [ ! -d "/usr/local/bin" ]; then
+	mkdir /usr/local/bin
+	sudo chmod 755 /usr/local/bin
 fi
+
+
+# Symlink $PS_EXECUTABLE to /usr/local/bin:
+sudo ln -s -f "$PS_EXECUTABLE" "/usr/local/bin/pennsieve"

--- a/ci/unix/mac_post_install.sh
+++ b/ci/unix/mac_post_install.sh
@@ -67,7 +67,7 @@ sudo chgrp -R staff "$PS_PATH"
 
 # Create /usr/local/bin if it does not exist
 if [ ! -d "/usr/local/bin" ]; then
-	mkdir /usr/local/bin
+	sudo mkdir /usr/local/bin
 	sudo chmod 755 /usr/local/bin
 fi
 


### PR DESCRIPTION
Our current post install *nix scripts assumes `/usr/local/bin `exists. However on a fresh out of the box Mac, that directory doesn't exist. Normally some other application will eventually create `/usr/local/bin` , but if Pennsieve is your 1st application installed then it will fail to symlink it.

This PR does two things:

1. Creates the `/usr/local/bin` directory if it doesn't exist
2. Makes the symlink without a conditional check around it since it should be created by the previous step
3. Add logging around the directory creation and symlink

Making this change for both MacOS and Linux. I have not see how the install functions on a fresh linux install, however it's reasonable to expect this could be the case on Linux too.