### PR TITLE
Separate workflow steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ server.lock
 # build
 pennsieve-agent
 .nextflow*
-work*
+work/

--- a/cmd/upload/manifest.go
+++ b/cmd/upload/manifest.go
@@ -56,7 +56,7 @@ var ManifestCmd = &cobra.Command{
 
 		manifestId := int32(i)
 		workflowPath, err := cmd.Flags().GetString("workflow")
-		workflowOpts, err := cmd.Flags().GetString("workflowOpts")
+		_, err = cmd.Flags().GetString("workflowOpts")
 
 		if err != nil {
 			log.Println("Workflow error: ", err)
@@ -66,8 +66,9 @@ var ManifestCmd = &cobra.Command{
 			WorkflowFlag: workflowPath,
 		}
 		if workflowPath != "" {
-			log.Println(workflowOpts)
+			log.Println("STARTING WORKFLOW")
 			workflowResponse, err := client.StartWorkflow(context.Background(), &WrkFlwReq)
+			log.Println("Workflow Response")
 			log.Println(workflowResponse)
 
 			// Stop upload if workflow fails

--- a/pkg/server/workflow.go
+++ b/pkg/server/workflow.go
@@ -150,13 +150,13 @@ func runWorkflow(workOrder *WorkOrder) {
 	output, err := cmd.Output()
 	fmt.Println(string(output))
 	if err != nil {
-		fmt.Println("failed on command execution")
+		fmt.Println("Workflow failed. See output above or .nextflow.log")
 
 		workOrder.Status = false
 	} else {
 		// Command completed successfully
 		workOrder.Status = true
-		fmt.Println("Command completed successfully")
+		fmt.Println("Workflow completed successfully")
 	}
 
 	writeWorkOrder(workOrder)

--- a/pkg/server/workflow.go
+++ b/pkg/server/workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"errors"
+	"fmt"
 	guuid "github.com/google/uuid"
 	api "github.com/pennsieve/pennsieve-agent/api/v1"
 	pb "github.com/pennsieve/pennsieve-agent/api/v1"
@@ -16,27 +17,30 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
 )
 
 type WorkOrder struct {
-	ProcessID      guuid.UUID                       `json:"ProcessID"`
-	FilePath       string                           `json:"FilePath"`
-	ManifestID     int32                            `json:"ManifestID"`
-	WorkFlowType   pb.WorkflowResponse_WorkflowType `json:"WorkFlowType"`
-	Input          string                           `json:"Input"`
-	Files          string                           `json:"Files"`
-	Status         bool                             `json:"Status"`
-	WorkFlowOutput string                           `json:"WorkFlowOutput"`
-	ManifestRoots  []string                         `json:"ManifestRoots"`
+	ProcessID          guuid.UUID                       `json:"ProcessID"`
+	FilePath           string                           `json:"FilePath"`
+	ManifestID         int32                            `json:"ManifestID"`
+	WorkFlowType       pb.WorkflowResponse_WorkflowType `json:"WorkFlowType"`
+	Input              string                           `json:"Input"`
+	Files              string                           `json:"Files"`
+	Status             bool                             `json:"Status"`
+	WorkFlowOutput     string                           `json:"WorkFlowOutput"`
+	ManifestRoots      []string                         `json:"ManifestRoots"`
+	NextflowConfigFile string                           `json:"NextflowConfigFile"`
 }
 
 func isPath(path string) bool {
 	_, err := os.Stat(path)
-	if !errors.Is(err, fs.ErrNotExist) {
-		log.Error(err)
+
+	if errors.Is(err, fs.ErrNotExist) {
+		fmt.Printf("Path error: %v", err)
 	}
 	if err == nil {
 		return true
@@ -48,8 +52,8 @@ func isPath(path string) bool {
 func (s *server) StartWorkflow(ctx context.Context, request *pb.StartWorkflowRequest) (*pb.WorkflowResponse, error) {
 
 	id := guuid.New()
-	log.Println("\nStarting workflow")
-	log.Println("ID:" + id.String())
+	fmt.Println("\nStarting workflow")
+	fmt.Println("ID:" + id.String())
 
 	var workOrder WorkOrder
 	var workflowType pb.WorkflowResponse_WorkflowType
@@ -64,7 +68,6 @@ func (s *server) StartWorkflow(ctx context.Context, request *pb.StartWorkflowReq
 	switch isPath(workOrder.Input) {
 
 	case true:
-		log.Println("Path workflow")
 		workOrder.WorkFlowType = pb.WorkflowResponse_PATH
 
 		newJobFolder := createWorkflowFolder(workOrder)
@@ -80,7 +83,7 @@ func (s *server) StartWorkflow(ctx context.Context, request *pb.StartWorkflowReq
 		conn, err := grpc.Dial(":"+port, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
 		if err != nil {
-			log.Fatal(err)
+			fmt.Printf("%v", err)
 
 		}
 		defer conn.Close()
@@ -88,7 +91,6 @@ func (s *server) StartWorkflow(ctx context.Context, request *pb.StartWorkflowReq
 		client := api.NewAgentClient(conn)
 		listFilesResponse, err := client.ListManifestFiles(context.Background(), &req)
 
-		log.Println("START  CSV Gen")
 		createInputCSV(&workOrder, listFilesResponse)
 		workOrder.ManifestRoots = getRootDirectories(listFilesResponse)
 
@@ -100,14 +102,14 @@ func (s *server) StartWorkflow(ctx context.Context, request *pb.StartWorkflowReq
 			"\ndocker{" +
 			"\n    enabled = true" +
 			"\n}"
-		os.WriteFile(filepath.Dir(workOrder.Input)+"/nextflow.config", []byte(nextflowConfigContent), 0644)
-		log.Println("Manifest roots")
-		log.Println(workOrder.ManifestRoots)
+
+		workOrder.NextflowConfigFile = filepath.Dir(newJobFolder) + "/" + workOrder.ProcessID.String() + "/nextflow.config"
+		err = os.WriteFile(workOrder.NextflowConfigFile, []byte(nextflowConfigContent), 0644)
 
 		runWorkflow(&workOrder)
 
 	case false:
-		log.Println("Named Workflow")
+		fmt.Println("Named Workflow")
 		workOrder.WorkFlowType = pb.WorkflowResponse_NAMED
 		workflowSteps := strings.Split(workOrder.Input, ",")
 
@@ -118,7 +120,7 @@ func (s *server) StartWorkflow(ctx context.Context, request *pb.StartWorkflowReq
 
 	response := pb.WorkflowResponse{
 		Success:      workOrder.Status,
-		Derivatives:  "test/path",
+		Derivatives:  "~/.pennsieve/derivatives",
 		WorkflowType: workflowType,
 	}
 
@@ -128,20 +130,30 @@ func (s *server) StartWorkflow(ctx context.Context, request *pb.StartWorkflowReq
 func runWorkflow(workOrder *WorkOrder) {
 
 	writeWorkOrder(workOrder)
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		fmt.Printf("Error getting current working directory: %v", err)
+		return
+	}
+
+	targetFolder := "workflow"
+	targetFile := "master_workflow.nf"
+	targetPath := filepath.Join(currentDir, targetFolder, targetFile)
+
 	app := "nextflow"
-	cmd := exec.Command(app, workOrder.Input, "--workflowJobId", workOrder.ProcessID.String())
+	cmd := exec.Command(app, targetPath, "--workflowJobId", workOrder.ProcessID.String(), "--userJob", workOrder.Input, "-c", workOrder.NextflowConfigFile)
 
 	output, err := cmd.Output()
+	fmt.Println(string(output))
 	if err != nil {
-		log.Println("failed on command execution")
-		log.Println(string(output))
+		fmt.Println("failed on command execution")
 
 		workOrder.Status = false
 	} else {
 		// Command completed successfully
-		log.Println(string(output))
 		workOrder.Status = true
-		log.Println("Command completed successfully")
+		fmt.Println("Command completed successfully")
 	}
 
 	writeWorkOrder(workOrder)
@@ -151,21 +163,24 @@ func writeWorkOrder(workOrder *WorkOrder) {
 	// Marshal the struct into JSON
 	jsonData, err := json.Marshal(workOrder)
 	if err != nil {
-		log.Fatal("Error marshaling JSON:", err)
+		fmt.Printf("Error marshaling JSON: %v", err)
 	}
 
 	// Write JSON data to a file
 	err = os.WriteFile(workOrder.FilePath+"/workflow/work_order.json", jsonData, 0644)
 	if err != nil {
-		log.Fatal("Error writing JSON to file:", err)
+		fmt.Printf("Error writing JSON to file: %v", err)
 	}
-	log.Println("JSON data written to work_order.json")
 }
 
 func createWorkflowFolder(workOrder WorkOrder) string {
 	// 2. Create Folder structure
-	pennsieveFolder := filepath.Dir(workOrder.Input)
-	jobsFolder := filepath.Join(pennsieveFolder, ".jobs")
+	currentUserHomeFolder, err := user.Current()
+	if err != nil {
+		fmt.Printf("Error in getting home folder: %v", err)
+	}
+
+	jobsFolder := filepath.Join(currentUserHomeFolder.HomeDir, ".pennsieve/.jobs")
 	if _, err := os.Stat(jobsFolder); errors.Is(err, os.ErrNotExist) {
 		if err := os.Mkdir(jobsFolder, os.ModePerm); err != nil {
 			log.Fatal(err)
@@ -183,7 +198,6 @@ func createWorkflowFolder(workOrder WorkOrder) string {
 }
 
 func createInputCSV(workOrder *WorkOrder, listFilesResponse *api.ListManifestFilesResponse) {
-	log.Println("Creating Input CSV file")
 
 	f, err := os.Create(workOrder.FilePath + "/workflow/input.csv")
 	workOrder.Files = f.Name()
@@ -191,16 +205,20 @@ func createInputCSV(workOrder *WorkOrder, listFilesResponse *api.ListManifestFil
 	record := []string{"id", "source_path", "target_path"}
 	err = w.Write(record)
 	if err != nil {
-		log.Println("Unable to write header")
+		fmt.Println("Unable to write header")
 	}
 	for _, file := range listFilesResponse.File {
 		record := []string{strconv.Itoa(int(file.Id)), file.SourcePath, file.TargetPath}
 		if err := w.Write(record); err != nil {
-			log.Fatalln("error writing record to file", err)
+			fmt.Printf("error writing record to file: %v", err)
 		}
 	}
 	w.Flush()
-	f.Close()
+	err = f.Close()
+	if err != nil {
+		fmt.Printf("Error closing file stream: %v", err)
+		return
+	}
 }
 
 func getRootDirectories(listFilesResponse *api.ListManifestFilesResponse) []string {

--- a/pkg/server/workflow_test.go
+++ b/pkg/server/workflow_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pennsieve/pennsieve-go-api/pkg/models/manifest/manifestFile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"path/filepath"
 	"testing"
 )
 
@@ -30,14 +31,14 @@ func (s *WorkflowTestSuite) TestGetRootDirectories() {
 	newFile := api.ListManifestFilesResponse_FileUpload{
 		Id:         61,
 		ManifestId: 10,
-		SourcePath: "/Volumes/mounted/.background/file3.md",
+		SourcePath: filepath.Clean("/Volumes/mounted/.background/file3.md"),
 		TargetPath: "",
 		UploadId:   "7d64320a-6399-4671-b2a8-6eec4e2650c5",
 		Status:     api.ListManifestFilesResponse_StatusType(manifestFile.Verified),
 	}
 	multipleRootDirs.File = append(multipleRootDirs.File, &newFile)
 
-	expectedMultipleRootDirResponse := append(expectedSingleRootDirResponse, "/Volumes/mounted/.background")
+	expectedMultipleRootDirResponse := append(expectedSingleRootDirResponse, filepath.Clean("/Volumes/mounted/.background"))
 	actualMultipleRootDirs := getRootDirectories(singleRootDir)
 
 	assert.Equal(s.T(), expectedSingleRootDirResponse, actualSingleRootDirResponse)
@@ -51,7 +52,7 @@ func TestWorkflowSuite(t *testing.T) {
 			{
 				Id:         61,
 				ManifestId: 10,
-				SourcePath: "/Users/pennUser/Documents/bids-data/.DS_Store",
+				SourcePath: filepath.Clean("/Users/pennUser/Documents/bids-data/.DS_Store"),
 				TargetPath: "",
 				UploadId:   "7d64320a-6399-4671-b2a8-6eec4e2650c1",
 				Status:     api.ListManifestFilesResponse_StatusType(manifestFile.Verified),
@@ -59,7 +60,7 @@ func TestWorkflowSuite(t *testing.T) {
 			{
 				Id:         62,
 				ManifestId: 10,
-				SourcePath: "/Users/pennUser/Documents/bids-data/.bidsignore",
+				SourcePath: filepath.Clean("/Users/pennUser/Documents/bids-data/.bidsignore"),
 				TargetPath: "",
 				UploadId:   "7d64320a-6399-4671-b2a8-6eec4e2650c2",
 				Status:     api.ListManifestFilesResponse_StatusType(manifestFile.Verified),
@@ -67,7 +68,7 @@ func TestWorkflowSuite(t *testing.T) {
 			{
 				Id:         63,
 				ManifestId: 10,
-				SourcePath: "/Users/pennUser/Documents/bids-data/sub-0001/ses-preimplant0001/eeg/sub-0001_ses-preimplant0001_task-task_run-01_eeg.json",
+				SourcePath: filepath.Clean("/Users/pennUser/Documents/bids-data/sub-0001/ses-preimplant0001/eeg/sub-0001_ses-preimplant0001_task-task_run-01_eeg.json"),
 				TargetPath: "",
 				UploadId:   "7d64320a-6399-4671-b2a8-6eec4e2650c3",
 				Status:     api.ListManifestFilesResponse_StatusType(manifestFile.Verified),
@@ -75,7 +76,7 @@ func TestWorkflowSuite(t *testing.T) {
 			{
 				Id:         64,
 				ManifestId: 10,
-				SourcePath: "/Users/pennUser/Documents/bids-data/sub-0001/.DS_Store",
+				SourcePath: filepath.Clean("/Users/pennUser/Documents/bids-data/sub-0001/.DS_Store"),
 				TargetPath: "",
 				UploadId:   "7d64320a-6399-4671-b2a8-6eec4e2650c4",
 				Status:     api.ListManifestFilesResponse_StatusType(manifestFile.Verified),

--- a/pkg/server/workflow_test.go
+++ b/pkg/server/workflow_test.go
@@ -23,7 +23,7 @@ getRootDirectories takes in *api.ListManifestFilesResponse
 and returns only the root most directories as an array
 */
 func (s *WorkflowTestSuite) TestGetRootDirectories() {
-	expectedSingleRootDirResponse := []string{"/Users/pennUser/Documents/bids-data"}
+	expectedSingleRootDirResponse := []string{filepath.Clean("/Users/pennUser/Documents/bids-data")}
 	actualSingleRootDirResponse := getRootDirectories(singleRootDir)
 
 	// Add a different root dir path

--- a/pkg/server/workflow_test.go
+++ b/pkg/server/workflow_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	api "github.com/pennsieve/pennsieve-agent/api/v1"
+	"github.com/pennsieve/pennsieve-go-api/pkg/models/manifest/manifestFile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"testing"
@@ -11,29 +13,74 @@ type WorkflowTestSuite struct {
 	suite.Suite
 }
 
-func (s *WorkflowTestSuite) TestWorkflow() {
-	filePaths := []string{
-		"/Users/code/pennsieve-agent/File1.jpg",
-		"/Users/code/pennsieve-agent/File2.jpg",
-		"/Users/code/pennsieve-agent/File3.jpg",
-		"/Users/code/pennsieve-agent/sub-folder/File3.jpg",
-		"/Users/code/pennsieve-agent/sub-folder/sub-sub-folder/File3.jpg",
-		"/Users/Documents/Adobe/File1.txt",
-		"/Users/Documents/Adobe/File2.txt",
-		"/Users/Documents/Adobe/images/File2.png",
-		"/Users/Documents/Adobe/backup/File2.txt",
-		"/Volumes/DBeaver Community/.background/file1.md",
-		"/Volumes/DBeaver Community/.background/file3.md",
+var (
+	singleRootDir *api.ListManifestFilesResponse
+)
+
+/*
+getRootDirectories takes in *api.ListManifestFilesResponse
+and returns only the root most directories as an array
+*/
+func (s *WorkflowTestSuite) TestGetRootDirectories() {
+	expectedSingleRootDirResponse := []string{"/Users/pennUser/Documents/bids-data"}
+	actualSingleRootDirResponse := getRootDirectories(singleRootDir)
+
+	// Add a different root dir path
+	multipleRootDirs := singleRootDir
+	newFile := api.ListManifestFilesResponse_FileUpload{
+		Id:         61,
+		ManifestId: 10,
+		SourcePath: "/Volumes/mounted/.background/file3.md",
+		TargetPath: "",
+		UploadId:   "7d64320a-6399-4671-b2a8-6eec4e2650c5",
+		Status:     api.ListManifestFilesResponse_StatusType(manifestFile.Verified),
 	}
+	multipleRootDirs.File = append(multipleRootDirs.File, &newFile)
 
-	paths := commonPathParts(filePaths[0], filePaths[1])
-	assert.Equal(s.T(), []string{"", "Users", "code", "pennsieve-agent"}, paths)
+	expectedMultipleRootDirResponse := append(expectedSingleRootDirResponse, "/Volumes/mounted/.background")
+	actualMultipleRootDirs := getRootDirectories(singleRootDir)
 
-	paths = commonPathParts(filePaths[3], filePaths[4])
-	assert.Equal(s.T(), []string{"", "Users", "code", "pennsieve-agent", "sub-folder"}, paths)
-	
+	assert.Equal(s.T(), expectedSingleRootDirResponse, actualSingleRootDirResponse)
+	assert.Contains(s.T(), expectedMultipleRootDirResponse, actualMultipleRootDirs[0])
+	assert.Contains(s.T(), expectedMultipleRootDirResponse, actualMultipleRootDirs[1])
 }
 
 func TestWorkflowSuite(t *testing.T) {
+	singleRootDir = &api.ListManifestFilesResponse{
+		File: []*api.ListManifestFilesResponse_FileUpload{
+			{
+				Id:         61,
+				ManifestId: 10,
+				SourcePath: "/Users/pennUser/Documents/bids-data/.DS_Store",
+				TargetPath: "",
+				UploadId:   "7d64320a-6399-4671-b2a8-6eec4e2650c1",
+				Status:     api.ListManifestFilesResponse_StatusType(manifestFile.Verified),
+			},
+			{
+				Id:         62,
+				ManifestId: 10,
+				SourcePath: "/Users/pennUser/Documents/bids-data/.bidsignore",
+				TargetPath: "",
+				UploadId:   "7d64320a-6399-4671-b2a8-6eec4e2650c2",
+				Status:     api.ListManifestFilesResponse_StatusType(manifestFile.Verified),
+			},
+			{
+				Id:         63,
+				ManifestId: 10,
+				SourcePath: "/Users/pennUser/Documents/bids-data/sub-0001/ses-preimplant0001/eeg/sub-0001_ses-preimplant0001_task-task_run-01_eeg.json",
+				TargetPath: "",
+				UploadId:   "7d64320a-6399-4671-b2a8-6eec4e2650c3",
+				Status:     api.ListManifestFilesResponse_StatusType(manifestFile.Verified),
+			},
+			{
+				Id:         64,
+				ManifestId: 10,
+				SourcePath: "/Users/pennUser/Documents/bids-data/sub-0001/.DS_Store",
+				TargetPath: "",
+				UploadId:   "7d64320a-6399-4671-b2a8-6eec4e2650c4",
+				Status:     api.ListManifestFilesResponse_StatusType(manifestFile.Verified),
+			},
+		},
+	}
 	suite.Run(t, new(WorkflowTestSuite))
 }

--- a/workflow/master_workflow.nf
+++ b/workflow/master_workflow.nf
@@ -1,0 +1,10 @@
+#!/usr/bin/env nextflow
+
+include {RUN_PREPROCESSOR} from './preprocessor.nf'
+include {main_flow} from "${params.userJob}"
+include {RUN_POSTPROCESSOR} from './postprocessor.nf'
+
+
+workflow {
+    RUN_PREPROCESSOR() | main_flow | RUN_POSTPROCESSOR | view { it.trim() }
+}

--- a/workflow/postprocessor.nf
+++ b/workflow/postprocessor.nf
@@ -1,0 +1,14 @@
+process RUN_POSTPROCESSOR {
+    container 'alpine'
+    memory '1GB'
+    input:
+    val postprocessor_input
+
+    output:stdout
+
+    script:
+    """
+    #! /bin/sh
+    echo 'hello postprocessor $postprocessor_input'
+    """
+}

--- a/workflow/preprocessor.nf
+++ b/workflow/preprocessor.nf
@@ -1,0 +1,13 @@
+process RUN_PREPROCESSOR {
+    container 'alpine'
+    memory '1GB'
+    output: stdout
+
+    script:
+    """
+    #!/bin/sh
+    echo '$params.workflowJobId'
+    python /build_virtual_path.py /job/workflow/input.csv
+    echo 'end preprocessing'
+    """
+}

--- a/workflow/preprocessor_build_virtual_path.py
+++ b/workflow/preprocessor_build_virtual_path.py
@@ -1,0 +1,74 @@
+import csv
+import os
+import sys
+import json
+
+SYMLINK_FOLDER = "/data"
+NEWPATH_DATA = {}
+MANIFEST_ROOTS = []
+
+def create_sym_link(source_path, target_path):
+    user_path = (os.path.expanduser('~'))
+    symlink_folder = "/data"
+    path_parts = source_path.split("/")
+    filename = path_parts[len(path_parts) - 1]
+    try:
+        target_path = f"{user_path}{symlink_folder}/{target_path}/{filename}"
+        print(target_path)
+
+        folder_path = os.path.dirname(target_path)
+        if os.path.exists(folder_path) == False:
+            os.makedirs(folder_path)
+
+        os.symlink(source_path, target_path)
+        print(f"Created symlink from {source_path} to {target_path}")
+    except FileExistsError as e:
+        print(f"Symlink already exists for {target_path}")
+    except FileNotFoundError as e:
+        print("File Error")
+        print(e)
+    except Exception as e:
+        print("Unexpected Error")
+        print(e)
+
+
+def build_container_csv_paths():
+    for root, dirs, files in os.walk(SYMLINK_FOLDER, topdown=True):
+        for file in files:
+            new_path = f"{root}/{file}"
+            NEWPATH_DATA[new_path] = new_path
+
+def get_manifest_roots():
+    f = open('/job/workflow/work_order.json')
+    work_order = json.load(f)
+    return work_order['ManifestRoots']
+
+def main(csv_file):
+    build_container_csv_paths()
+    dir_roots = get_manifest_roots()
+    print(NEWPATH_DATA)
+    with open(csv_file, 'r') as file:
+        reader = csv.DictReader(file)
+        headers = reader.fieldnames
+
+        if 'source_path' not in headers or 'target_path' not in headers:
+            print("Required headers not found in CSV file.")
+            return
+
+        for row in reader:
+
+            # replace user machine path with container path
+            for root in dir_roots:
+                source_path = row['source_path'].replace(root, SYMLINK_FOLDER)
+
+            target_path = row['target_path']
+            create_sym_link(source_path, target_path)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <csv_file>")
+        sys.exit(1)
+
+    csv_file = sys.argv[1]
+    main(sys.argv[1])


### PR DESCRIPTION
* Correctly log output via agent using `fmt` vs `log` library
* Build out required directories and config files on the fly
* Separate workflow into distinct steps: Preprocessor, user defined, Postprocessor
* Add python script to build virtual directories for preprocessor
* Some cleanup in variable names

This PR represents a single step along the way of separating concerns with workflows. Future PRs will continue to evolve separating these concerns