### PR TITLE
Auto add base path flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Second iteration of the Pennsieve Agent
 
 ## Installing the Pennsieve Agent
 
-### Using the Installlers (recommended)
+### Using the Installers (recommended)
 
 Download the latest installer for your operating system: https://github.com/Pennsieve/pennsieve-agent/releases
 
@@ -42,7 +42,7 @@ Download the latest installer for your operating system: https://github.com/Penn
     - MINOR version when you add functionality in a backwards compatible manner, and
     - PATCH version when you make backwards compatible bug fixes.
 
-3. Push the tag to Gihub
+3. Push the tag to GitHub
 
     eg. ```git push origin 0.0.1```
     

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Second iteration of the Pennsieve Agent
 
 Download the latest installer for your operating system: https://github.com/Pennsieve/pennsieve-agent/releases
 
-- Windows and MacOS release come with graphical installers (.msi and .pkg )
+- Windows and MacOS release come with graphical wizard installers (.msi and .pkg )
 
 - For *nix environments use `dpkg -i  pennsieve-VERSION_amd64.deb` to install
 
@@ -29,8 +29,6 @@ Download the latest installer for your operating system: https://github.com/Penn
 2. Install Golang on the machine
 3. Run `go build` or `go install` in the pennsieve-agent folder
 4. Symlink "pennsieve" to the output (the linux executable is called 'pennsieve-agent' instead of 'pennsieve')
-
-
 
 
 ## Releasing a new version

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Second iteration of the Pennsieve Agent
 
 Download the latest installer for your operating system: https://github.com/Pennsieve/pennsieve-agent/releases
 
+- Windows and MacOS release come with graphical installers (.msi and .pkg )
+
+- For *nix environments use `dpkg -i  pennsieve-VERSION_amd64.deb` to install
+
 ### From Source
 
 1. Clone the Pennsieve Agent repository

--- a/cmd/config/init.go
+++ b/cmd/config/init.go
@@ -96,10 +96,10 @@ func init() {
 		"user", "Profile name to be associated with provided api key/secret")
 
 	InitCmd.Flags().String("api_token",
-		"", "Target base path in dataset.")
+		"", "API Token.")
 
 	InitCmd.Flags().String("api_secret",
-		"", "Target base path in dataset.")
+		"", "Api Secret.")
 
 	InitCmd.Flags().BoolP("force", "f",
 		false, "Force creation of config file.")

--- a/cmd/manifest/create.go
+++ b/cmd/manifest/create.go
@@ -27,7 +27,7 @@ var CreateCmd = &cobra.Command{
 			return
 		} else if targetAutoPath {
 			//Get leaf directory
-			targetBasePath = shared.GetLeafDirectory(basePath, string(filepath.Separator))
+			targetBasePath = filepath.Base(basePath)
 		}
 
 		req := api.CreateManifestRequest{

--- a/cmd/manifest/create.go
+++ b/cmd/manifest/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"path/filepath"
 )
 
 var CreateCmd = &cobra.Command{
@@ -18,9 +19,19 @@ var CreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		targetBasePath, _ := cmd.Flags().GetString("target_path")
+		targetAutoPath, _ := cmd.Flags().GetBool("auto_path")
+		basePath := args[0]
+
+		if targetAutoPath && targetBasePath != "" {
+			fmt.Println("Cannot set auto path and target path")
+			return
+		} else if targetAutoPath {
+			//Get leaf directory
+			targetBasePath = shared.GetLeafDirectory(basePath, string(filepath.Separator))
+		}
 
 		req := api.CreateManifestRequest{
-			BasePath:       args[0],
+			BasePath:       basePath,
 			TargetBasePath: targetBasePath,
 			Recursive:      true,
 		}
@@ -47,4 +58,8 @@ var CreateCmd = &cobra.Command{
 func init() {
 	CreateCmd.Flags().StringP("target_path", "t",
 		"", "Target base path in dataset.")
+
+	CreateCmd.Flags().BoolP("auto_path", "a",
+		false, "Automatically creates the base path for dataset using the last folder in the given path")
+
 }

--- a/cmd/manifest/create.go
+++ b/cmd/manifest/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"os"
 	"path/filepath"
 )
 
@@ -28,6 +29,22 @@ var CreateCmd = &cobra.Command{
 		} else if targetAutoPath {
 			//Get leaf directory
 			targetBasePath = filepath.Base(basePath)
+			fileInfo, err := os.Stat(basePath)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+
+			// Check if user is sending
+			if !fileInfo.IsDir() {
+				// ANSI escape code for bold text
+				bold := "\033[1m"
+				// ANSI escape code to reset text attributes
+				reset := "\033[0m"
+				fmt.Println(bold + "Using auto_path with a file instead of a folder.")
+				fmt.Println("Are you sure you want to do this?" + reset)
+			}
+
 		}
 
 		req := api.CreateManifestRequest{

--- a/cmd/shared/helpers.go
+++ b/cmd/shared/helpers.go
@@ -1,0 +1,15 @@
+// Package shared helpers.go: For short helper functions that may find use across packages
+package shared
+
+import (
+	"strings"
+)
+
+// GetLeafDirectory Return the leaf directory from a file path
+func GetLeafDirectory(inputPath string, osFilePathSeparator string) string {
+
+	tokens := strings.Split(inputPath, osFilePathSeparator)
+	numTokens := len(tokens)
+
+	return tokens[numTokens-1]
+}

--- a/cmd/shared/helpers.go
+++ b/cmd/shared/helpers.go
@@ -1,15 +1,4 @@
 // Package shared helpers.go: For short helper functions that may find use across packages
 package shared
 
-import (
-	"strings"
-)
-
-// GetLeafDirectory Return the leaf directory from a file path
-func GetLeafDirectory(inputPath string, osFilePathSeparator string) string {
-
-	tokens := strings.Split(inputPath, osFilePathSeparator)
-	numTokens := len(tokens)
-
-	return tokens[numTokens-1]
-}
+// Add Helper functions here as required

--- a/cmd/shared/helpers_test.go
+++ b/cmd/shared/helpers_test.go
@@ -1,0 +1,35 @@
+package shared
+
+import (
+	"github.com/stretchr/testify/suite"
+)
+
+import (
+	"testing"
+)
+
+type HelpersTestSuite struct {
+	suite.Suite
+}
+
+func (h *HelpersTestSuite) TestGetLeafDirectory() {
+	nixDirs := [3]string{
+		"/Users/etrakand/Documents/scan-data-01.02.03",
+		"/Users/ralthor/Downloads/chop_data",
+		"~/docs/folder",
+	}
+
+	winDirs := [3]string{
+		"C:\\Documents\\pebara\\wolves",
+	}
+	h.Equal(GetLeafDirectory(nixDirs[0], "/"), "scan-data-01.02.03")
+	h.Equal(GetLeafDirectory(nixDirs[1], "/"), "chop_data")
+	h.Equal(GetLeafDirectory(nixDirs[2], "/"), "folder")
+
+	h.Equal(GetLeafDirectory(winDirs[0], "\\"), "wolves")
+
+}
+
+func TestDatasetsSuite(t *testing.T) {
+	suite.Run(t, new(HelpersTestSuite))
+}

--- a/cmd/shared/helpers_test.go
+++ b/cmd/shared/helpers_test.go
@@ -12,22 +12,9 @@ type HelpersTestSuite struct {
 	suite.Suite
 }
 
-func (h *HelpersTestSuite) TestGetLeafDirectory() {
-	nixDirs := [3]string{
-		"/Users/etrakand/Documents/scan-data-01.02.03",
-		"/Users/ralthor/Downloads/chop_data",
-		"~/docs/folder",
-	}
-
-	winDirs := [3]string{
-		"C:\\Documents\\pebara\\wolves",
-	}
-	h.Equal(GetLeafDirectory(nixDirs[0], "/"), "scan-data-01.02.03")
-	h.Equal(GetLeafDirectory(nixDirs[1], "/"), "chop_data")
-	h.Equal(GetLeafDirectory(nixDirs[2], "/"), "folder")
-
-	h.Equal(GetLeafDirectory(winDirs[0], "\\"), "wolves")
-
+// Add test for helper functions as required
+func (h *HelpersTestSuite) TestStubFunction() {
+	h.Equal(true, true)
 }
 
 func TestDatasetsSuite(t *testing.T) {


### PR DESCRIPTION
Users have been asking for a flag to automatically use the last folder as the target path.

The `-t` flag exists, but I've seen users run into issues with this such as:
- spelling errors
- giving the incorrect path

All easy to fix, but adds another step to their workflows to fix. This flag is a convenience flag which will simply take the leaf directory and make that the base path for the data.

PR adds:
- New flag `--auto_path` and shorthand `-a`
- Adds helpers.go which has helper function `GetLeafDirectory`
- Test for `GetLeafDirectory`
- Also fixed some spelling errors on the README and clarify some installer instructions

Usage: `pennsieve manifest create ~/Documents/bdsp-data --auto_path` or `pennsieve manifest create ~/Documents/bdsp-data -a`

Both of these will set the base path to `bdsp-data` which will become a folder in Pennsieve that all the data goes to.

Trying to set a base path with `-t`and using the `--auto_path` flag will cause an error:
`pennsieve manifest create ~/Documents/bdsp-data --auto_path -t my_new_path`
`Cannot set auto path and target path`