### PR TITLE
fix: allows a compute resource to be registered across multiple workspaces

### DIFF
--- a/internal/account/registration.go
+++ b/internal/account/registration.go
@@ -2,4 +2,5 @@ package account
 
 type Registration interface {
 	Create() ([]byte, error)
+	GetAccountId() (string, error)
 }

--- a/internal/aws/role_manager_test.go
+++ b/internal/aws/role_manager_test.go
@@ -9,8 +9,9 @@ import (
 func TestRoleManager(t *testing.T) {
 	accountId := "someAccountId"
 	profile := "someProfile"
+	roleName := "someRoleName"
 
-	roleManager := NewAWSRoleManager(accountId, profile)
+	roleManager := NewAWSRoleManager(accountId, profile, roleName)
 
 	_, err := roleManager.Create()
 	assert.Error(t, err)


### PR DESCRIPTION
- allows creation of database entry even when the compute resource `role` exists
- this change will allow us to have the same compute resource registered in multiple workspaces

Related ticket: https://github.com/Pennsieve/account-service/pull/17