### PR TITLE
Set paths correctly for db migration and migration sql

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,13 +119,13 @@ func initViper() error {
 
 	// Setup paths for portability
 	absPath, err := filepath.Abs(home)
-	migrationsPath = path.Join(absPath, migrationsFolders)
-	migrationsPath = fmt.Sprintf("file://%s", filepath.ToSlash(migrationsPath))
+	dbMigrationsPath := path.Join(absPath, migrationsFolders)
+	dbMigrationsPath = fmt.Sprintf("file://%s", filepath.ToSlash(migrationsPath))
 
 	viper.SetDefault("global.default_profile", "pennsieve")
 	viper.SetDefault("agent.db_path", dbPath)
 	viper.SetDefault("agent.useConfigFile", true)
-	viper.SetDefault("migration.path", migrationsPath)
+	viper.SetDefault("migration.path", dbMigrationsPath)
 	err = extractMigrations(migrationsFS, migrationsPath)
 
 	workers := os.Getenv("PENNSIEVE_AGENT_UPLOAD_WORKERS")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/pennsieve/pennsieve-agent/cmd/download"
@@ -118,9 +117,7 @@ func initViper() error {
 	}
 
 	// Setup paths for portability
-	absPath, err := filepath.Abs(home)
-	dbMigrationsPath := path.Join(absPath, migrationsFolders)
-	dbMigrationsPath = fmt.Sprintf("file://%s", filepath.ToSlash(migrationsPath))
+	dbMigrationsPath := fmt.Sprintf("file://%s", filepath.ToSlash(migrationsPath))
 
 	viper.SetDefault("global.default_profile", "pennsieve")
 	viper.SetDefault("agent.db_path", dbPath)

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -42,7 +42,7 @@ func InitializeDB() (*sql.DB, error) {
 	}
 	if err := m.Up(); err != nil {
 		if errors.Is(err, migrate.ErrNoChange) {
-			log.Info("No change in database schema: ", err)
+			log.Debug("No change in database schema: ", err)
 		} else {
 			log.Error(err)
 			return nil, err


### PR DESCRIPTION
Migration path would fail for clients who previously did not have a migrations folder due to the extraction path being updated to the new file:// style of when `extractManifest` required just the raw OS path.

Tested on a fresh wipe of the .pennsieve folder on Windows 11 and Mac OS