### PR TITLE
868dmw6hc add busy timeout for sqllite connections

### DIFF
--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -26,7 +26,7 @@ func InitializeDB() (*sql.DB, error) {
 	dbPath := viper.GetString("agent.db_path")
 	migrationPath := viper.GetString("migration.path")
 
-	db, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=on&mode=rwc&_journal_mode=WAL")
+	db, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=on&mode=rwc&_journal_mode=WAL&_busy_timeout=15000")
 	if err != nil {
 		log.Error("Unable to open database")
 	}


### PR DESCRIPTION
## Motivation
**ClickUp Ticket:** [868dmw6hc](https://app.clickup.com/t/868dmw6hc)

Reproduced the error in the bug ticket when uploading 300K+ files to Pennsieve via the agent. The call to mark the manifest file record in the SQLite database was failing with a `database is locked` error due to concurrent write attempts.

The assumption is that the there is another query holding on to the database lock for longer than normal due to the size of the manifest files table (with 300K+ records) in it causing the writes to actually happen concurrently with consistency.

SQLite allows for connections to busy wait for other connections to release locks. Adding this configuration has allowed the locally replicated setup to upload files without issue.

This is a temporary, band-aid solution to unblock the user. A more formal solution would centralize writes or properly handle the concurrency in the application layer so multiple connections don't connected for the same write-access.