### PR TITLE
868dmw6hc refactor upload for single update writer

### DIFF
--- a/pkg/models/server.go
+++ b/pkg/models/server.go
@@ -1,1 +1,0 @@
-package models

--- a/pkg/models/upload.go
+++ b/pkg/models/upload.go
@@ -1,0 +1,8 @@
+package models
+
+import "github.com/pennsieve/pennsieve-go-core/pkg/models/manifest/manifestFile"
+
+type UploadStatusUpdateMessage struct {
+	UploadID string
+	Status   manifestFile.Status
+}

--- a/pkg/server/manifest.go
+++ b/pkg/server/manifest.go
@@ -375,7 +375,6 @@ func (s *agentServer) syncProcessor(ctx context.Context, m *store.Manifest) (*sy
 	s.ManifestService().SyncResponseStatusUpdate(m.Id, allStatusUpdates)
 
 	return &syncSummary{nrFilesUpdated: len(allStatusUpdates)}, nil
-
 }
 
 // getCreateManifestId takes a manifest and ensures the manifest has a node-id.

--- a/pkg/server/manifest.go
+++ b/pkg/server/manifest.go
@@ -288,6 +288,9 @@ func (s *agentServer) syncProcessor(ctx context.Context, m *store.Manifest) (*sy
 
 	nrWorkers := viper.GetInt("agent.upload_workers")
 	syncWalker := make(chan store.ManifestFile, nrWorkers)
+
+	// type recordWalk chan record
+	type syncResult chan []manifestFile.FileStatusDTO
 	syncResults := make(syncResult, nrWorkers)
 
 	totalNrRows, err := s.ManifestService().GetNumberOfRowsForStatus(m.Id,

--- a/pkg/service/manifest.go
+++ b/pkg/service/manifest.go
@@ -23,15 +23,11 @@ func NewManifestService(ms store.ManifestStore, mfs store.ManifestFileStore, cli
 	}
 }
 
-//func (s *ManifestService) SetPennsieveClient(client *pennsieve.Client) {
-//	s.client = client
-//}
-
 // VerifyFinalizedStatus checks if files are in "Finalized" state on server and sets to "Verified"
-func (s *ManifestService) VerifyFinalizedStatus(manifest *store.Manifest) error {
+func (s *ManifestService) VerifyFinalizedStatus(ctx context.Context, manifest *store.Manifest) error {
 	log.Debug("Verifying files")
 
-	response, err := s.client.Manifest.GetFilesForStatus(nil, manifest.NodeId.String, manifestFile.Finalized, "", true)
+	response, err := s.client.Manifest.GetFilesForStatus(ctx, manifest.NodeId.String, manifestFile.Finalized, "", true)
 	if err != nil {
 		log.Error("Error getting files for status, here is why: ", err)
 		return err
@@ -49,7 +45,7 @@ func (s *ManifestService) VerifyFinalizedStatus(manifest *store.Manifest) error 
 	for {
 		if len(response.ContinuationToken) > 0 {
 			log.Debug("Getting another set of files ")
-			response, err = s.client.Manifest.GetFilesForStatus(nil, manifest.NodeId.String, manifestFile.Finalized, response.ContinuationToken, true)
+			response, err = s.client.Manifest.GetFilesForStatus(ctx, manifest.NodeId.String, manifestFile.Finalized, response.ContinuationToken, true)
 			if err != nil {
 				log.Error("Error getting files for status, here is why: ", err)
 				return err
@@ -70,44 +66,35 @@ func (s *ManifestService) VerifyFinalizedStatus(manifest *store.Manifest) error 
 }
 
 func (s *ManifestService) GetManifest(manifestId int32) (*store.Manifest, error) {
-	manifest, err := s.mStore.Get(manifestId)
-	return manifest, err
+	return s.mStore.Get(manifestId)
 }
 
 func (s *ManifestService) GetAll() ([]store.Manifest, error) {
-	manifests, err := s.mStore.GetAll()
-	return manifests, err
+	return s.mStore.GetAll()
 }
 
 func (s *ManifestService) Add(params store.ManifestParams) (*store.Manifest, error) {
-	manifest, err := s.mStore.Add(params)
-	return manifest, err
+	return s.mStore.Add(params)
 }
 
 func (s *ManifestService) RemoveFromManifest(manifestId int32, removePath string) error {
-	err := s.mfStore.RemoveFromManifest(manifestId, removePath)
-	return err
+	return s.mfStore.RemoveFromManifest(manifestId, removePath)
 }
 
 func (s *ManifestService) RemoveManifest(manifestId int32) error {
-	err := s.mStore.Remove(manifestId)
-	return err
+	return s.mStore.Remove(manifestId)
 }
 
 func (s *ManifestService) GetFiles(manifestId int32, limit int32, offset int32) ([]store.ManifestFile, error) {
-	files, err := s.mfStore.Get(manifestId, limit, offset)
-	return files, err
+	return s.mfStore.Get(manifestId, limit, offset)
 }
 
 func (s *ManifestService) ResetStatusForManifest(manifestId int32) error {
-	err := s.mfStore.ResetStatusForManifest(manifestId)
-	return err
+	return s.mfStore.ResetStatusForManifest(manifestId)
 }
 
 func (s *ManifestService) GetNumberOfRowsForStatus(manifestId int32, statusArr []manifestFile.Status, invert bool) (int64, error) {
-	result, err := s.mfStore.GetNumberOfRowsForStatus(manifestId, statusArr, invert)
-	return result, err
-
+	return s.mfStore.GetNumberOfRowsForStatus(manifestId, statusArr, invert)
 }
 
 func (s *ManifestService) ManifestFilesToChannel(ctx context.Context, manifestId int32, statusArr []manifestFile.Status, walker chan<- store.ManifestFile) {
@@ -115,8 +102,7 @@ func (s *ManifestService) ManifestFilesToChannel(ctx context.Context, manifestId
 }
 
 func (s *ManifestService) SyncResponseStatusUpdate(manifestId int32, statusList []manifestFile.FileStatusDTO) error {
-	err := s.mfStore.SyncResponseStatusUpdate(manifestId, statusList)
-	return err
+	return s.mfStore.SyncResponseStatusUpdate(manifestId, statusList)
 }
 
 // SetManifestNodeId updates the manifest Node ID in the Manifest object and Database
@@ -127,16 +113,13 @@ func (s *ManifestService) SetManifestNodeId(m *store.Manifest, nodeId string) er
 		Valid:  true,
 	}
 
-	err := s.mStore.SetManifestNodeId(m.Id, nodeId)
-	return err
+	return s.mStore.SetManifestNodeId(m.Id, nodeId)
 }
 
 func (s *ManifestService) AddFiles(records []store.ManifestFileParams) error {
-	err := s.mfStore.Add(records)
-	return err
+	return s.mfStore.Add(records)
 }
 
 func (s *ManifestService) SetFileStatus(uploadId string, status manifestFile.Status) error {
-	err := s.mfStore.SetStatus(status, uploadId)
-	return err
+	return s.mfStore.SetStatus(status, uploadId)
 }

--- a/pkg/service/manifest.go
+++ b/pkg/service/manifest.go
@@ -131,3 +131,7 @@ func (s *ManifestService) AddFiles(records []store.ManifestFileParams) error {
 func (s *ManifestService) SetFileStatus(uploadId string, status manifestFile.Status) error {
 	return s.mfStore.SetStatus(status, uploadId)
 }
+
+func (s *ManifestService) BatchSetFileStatus(uploadIds []string, status manifestFile.Status) error {
+	return s.mfStore.BatchSetStatus(status, uploadIds)
+}


### PR DESCRIPTION
**ClickUp Ticket:** [868dmw6hc](https://app.clickup.com/t/868dmw6hc)

User was seeing `database is locked` errors while attempting to upload a large number of files, causing the agent to crash.

The issue was reproducible by similarly uploading a large number (300K+) of small (21B), same size files. 

Root cause analysis suggests the agent was failing to acquire a SQLite lock on the database while performing many concurrent updates to the manifest file status.

SQLite does not support many-writer concurrency well due to the nature of how it serializes writes to the DB.

Initially solution: https://github.com/Pennsieve/pennsieve-agent/pull/64 added a busy timeout to SQLite connections so that they would wait for a lock. But even this wait would eventually lead to one connection failing to acquire a lock.

This PR refactors writes to the databases to be serialized and done in batch by a single database connection.

This does not solve the root issue with the agent where a client can make many concurrent requests to the agent server and still perform many writes but it at least alleivates a user wanting to upload many files without having to constantly re-start the agent.