### PR TITLE
Update 'manifest remove' help and output message

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ "**" ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ "**" ]
+  workflow_dispatch:
 
 jobs:
 

--- a/cmd/manifest/manifest.go
+++ b/cmd/manifest/manifest.go
@@ -14,7 +14,44 @@ import (
 	"unicode"
 )
 
-var ManifestCmd = NewManifestCmd()
+var ManifestCmd = &cobra.Command{
+	Use:   "manifest",
+	Short: "Lists upload manifests.",
+	Long: `Renders a list of upload manifests and their current status. 
+
+This list includes only upload manifests that are initiated from the current machine.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		req := api.ListManifestsRequest{}
+
+		port := viper.GetString("agent.port")
+		conn, err := grpc.Dial(":"+port, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			fmt.Println("Error connecting to GRPC Server: ", err)
+			return
+		}
+		defer conn.Close()
+
+		client := api.NewAgentClient(conn)
+		manifestResponse, err := client.ListManifests(context.Background(), &req)
+		if err != nil {
+			st := status.Convert(err)
+			fmt.Println(st.Message())
+			return
+		}
+
+		t := table.NewWriter()
+		t.SetOutputMirror(os.Stdout)
+		t.AppendHeader(table.Row{"Upload Manifest", "User Name", "Organization Name", "Dataset ID", "Status", "nodeId"})
+		for _, s := range manifestResponse.Manifests {
+			const maxLength = 100
+			dsName := trimName(s.DatasetName, maxLength)
+			t.AppendRow([]interface{}{s.Id, s.UserName, s.OrganizationName, dsName, s.Status, s.NodeId})
+		}
+
+		t.Render()
+	},
+}
 
 func init() {
 	ManifestCmd.AddCommand(ListCmd)
@@ -24,50 +61,6 @@ func init() {
 	ManifestCmd.AddCommand(DeleteCmd)
 	ManifestCmd.AddCommand(SyncCmd)
 	ManifestCmd.AddCommand(ResetCmd)
-}
-
-// NewManifestCmd returns a manifest command without any child commands.
-// Useful for testing since the re-use of a global ManifestCmd variable in tests causes
-// problems with flag values being retained, and so one test can pollute another when run in parallel.
-func NewManifestCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "manifest",
-		Short: "Lists upload manifests.",
-		Long: `Renders a list of upload manifests and their current status. 
-
-This list includes only upload manifests that are initiated from the current machine.`,
-		Run: func(cmd *cobra.Command, args []string) {
-
-			req := api.ListManifestsRequest{}
-
-			port := viper.GetString("agent.port")
-			conn, err := grpc.Dial(":"+port, grpc.WithTransportCredentials(insecure.NewCredentials()))
-			if err != nil {
-				fmt.Println("Error connecting to GRPC Server: ", err)
-				return
-			}
-			defer conn.Close()
-
-			client := api.NewAgentClient(conn)
-			manifestResponse, err := client.ListManifests(context.Background(), &req)
-			if err != nil {
-				st := status.Convert(err)
-				fmt.Println(st.Message())
-				return
-			}
-
-			t := table.NewWriter()
-			t.SetOutputMirror(os.Stdout)
-			t.AppendHeader(table.Row{"Upload Manifest", "User Name", "Organization Name", "Dataset ID", "Status", "nodeId"})
-			for _, s := range manifestResponse.Manifests {
-				const maxLength = 100
-				dsName := trimName(s.DatasetName, maxLength)
-				t.AppendRow([]interface{}{s.Id, s.UserName, s.OrganizationName, dsName, s.Status, s.NodeId})
-			}
-
-			t.Render()
-		},
-	}
 }
 
 func trimName(str string, max int) string {

--- a/cmd/manifest/remove.go
+++ b/cmd/manifest/remove.go
@@ -24,8 +24,8 @@ func NewRemoveCmd() *cobra.Command {
 		Use:   "remove -m MANIFEST-ID SOURCE-PATH-PREFIX",
 		Short: "Removes files from an existing manifest.",
 		Long: `Removes files from an existing manifest.
-This command will remove any files from the manifest with id MANIFEST-ID with status Local and with a source path that starts with SOURCE-PATH-PREFIX.
-If a file in the manifest has a source path starting with SOURCE-PATH-PREFIX and status Registered, then the status will be updated to Removed.`,
+This command will remove any files from the manifest with id MANIFEST-ID with status LOCAL and with a source path that starts with SOURCE-PATH-PREFIX.
+If a file in the manifest has a source path starting with SOURCE-PATH-PREFIX and status REGISTERED, then the status will be updated to Removed.`,
 		// this is the one positional arg, the source path
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/manifest/remove.go
+++ b/cmd/manifest/remove.go
@@ -24,8 +24,8 @@ func NewRemoveCmd() *cobra.Command {
 		Use:   "remove -m MANIFEST-ID SOURCE-PATH-PREFIX",
 		Short: "Removes files from an existing manifest.",
 		Long: `Removes files from an existing manifest.
-This command will remove any files from the manifest with id MANIFEST-ID with status LOCAL and with a source path that starts with SOURCE-PATH-PREFIX.
-If a file in the manifest has a source path starting with SOURCE-PATH-PREFIX and status REGISTERED, then the status will be updated to Removed.`,
+This command will remove any files that have a source path starting with SOURCE-PATH-PREFIX and having status LOCAL from the given manifest.
+If a file in the manifest has a source path starting with SOURCE-PATH-PREFIX and status REGISTERED, then the status will be updated to REMOVED.`,
 		// this is the one positional arg, the source path
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/manifest/remove.go
+++ b/cmd/manifest/remove.go
@@ -21,9 +21,11 @@ func NewRemoveCmd() *cobra.Command {
 	manifestIdFlag := "manifest_id"
 
 	cmd := &cobra.Command{
-		Use:   "remove -m MANIFEST-ID SOURCE-PATH",
-		Short: "Removes a file from an existing manifest.",
-		Long:  `Removes a file from an existing manifest.`,
+		Use:   "remove -m MANIFEST-ID SOURCE-PATH-PREFIX",
+		Short: "Removes files from an existing manifest.",
+		Long: `Removes files from an existing manifest.
+This command will remove any files from the manifest with id MANIFEST-ID with status Local and with a source path that starts with SOURCE-PATH-PREFIX.
+If a file in the manifest has a source path starting with SOURCE-PATH-PREFIX and status Registered, then the status will be updated to Removed.`,
 		// this is the one positional arg, the source path
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -38,7 +40,7 @@ func NewRemoveCmd() *cobra.Command {
 			// Args field in this Command ensures we only get here if len(args) == 1
 			sourcePath := args[0]
 
-			printOut(cmd, fmt.Sprintf("source path: %s", sourcePath))
+			printOut(cmd, fmt.Sprintf("source path prefix: %s", sourcePath))
 
 			req := api.RemoveFromManifestRequest{
 				ManifestId: manifestId,

--- a/cmd/manifest/remove_test.go
+++ b/cmd/manifest/remove_test.go
@@ -36,7 +36,7 @@ func TestRemoveCmd_Help(t *testing.T) {
 	require.NoError(t, removeCmd.Execute())
 
 	output := readBuffer(t, outBuffer)
-	assert.Contains(t, output, "remove -m MANIFEST-ID SOURCE-PATH")
+	assert.Contains(t, output, "remove -m MANIFEST-ID SOURCE-PATH-PREFIX")
 
 	assert.Empty(t, errBuffer)
 }
@@ -68,7 +68,7 @@ func TestRemoveCmd_BadArgs(t *testing.T) {
 
 			stdout := readBuffer(t, outBuffer)
 			// fmt.Println("stdout", stdout)
-			assert.Contains(t, stdout, "remove -m MANIFEST-ID SOURCE-PATH")
+			assert.Contains(t, stdout, "remove -m MANIFEST-ID SOURCE-PATH-PREFIX")
 
 			stderr := readBuffer(t, errBuffer)
 			//fmt.Println("stderr", stderr)

--- a/cmd/manifest/remove_test.go
+++ b/cmd/manifest/remove_test.go
@@ -136,6 +136,8 @@ func (m mockRemoveFromManifest) RemoveFromManifest(ctx context.Context, req *v1.
 	return m.f(ctx, req)
 }
 
+// SetViper sets the given key to the given value in viper. Since viper uses global singletons, a cleanup function is registered
+// on t that restores any previous value associated with key.
 func SetViper(t *testing.T, key string, value any) {
 	old := viper.Get(key)
 	t.Cleanup(func() {

--- a/cmd/manifest/remove_test.go
+++ b/cmd/manifest/remove_test.go
@@ -146,7 +146,7 @@ func SetViper(t *testing.T, key string, value any) {
 	viper.Set(key, value)
 }
 
-// StartMockGRPC starts a GPRC server that registers mock as the v1.AgentServer
+// StartMockGRPC starts a GPRC server that registers mock as the v1.AgentServer.
 // Server and listener Close() are registered to t's Cleanup() method.
 func StartMockGRPC(t *testing.T, mock v1.AgentServer) (port string) {
 	lis, err := net.Listen("tcp", "127.0.0.1:0")

--- a/cmd/manifest/remove_test.go
+++ b/cmd/manifest/remove_test.go
@@ -1,0 +1,129 @@
+package manifest
+
+import (
+	"context"
+	v1 "github.com/pennsieve/pennsieve-agent/api/v1"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"net"
+	"strconv"
+	"testing"
+)
+
+func TestRemoveCmd_Help(t *testing.T) {
+	// Must do everything through parent command since running Execute()
+	// on child command runs it from the parent anyway.
+	removeCmd := NewRemoveCmd()
+	removeCmd.SetArgs([]string{"--help"})
+	require.NoError(t, removeCmd.Execute())
+}
+
+func TestRemoveCmd_BadArgs(t *testing.T) {
+	tests := []struct {
+		scenario string
+		args     []string
+	}{
+		{"no args", []string{}},
+		{"only positional arg", []string{"path/to/file"}},
+		{"only flag, no value", []string{"-m"}},
+		{"wrong manifest id type", []string{"-m", "my-manifest"}},
+		{"wrong flag", []string{"-m", "3", "--not-a-flag"}},
+		{"no path", []string{"-m", "3"}},
+		{"more than one path", []string{"-m", "3", "path/to/file1.txt", "path/to/file2.txt"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.scenario, func(t *testing.T) {
+			removeCmd := NewRemoveCmd()
+			removeCmd.SetArgs(tt.args)
+			err := removeCmd.Execute()
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestRemoveCmd(t *testing.T) {
+	manifestID := int32(3)
+	path := "path/1/test.txt"
+	expectedStatus := "all good"
+	port := StartMockGRPC(t,
+		newMockRemoveFromManifest(func(_ context.Context, request *v1.RemoveFromManifestRequest) (*v1.SimpleStatusResponse, error) {
+			assert.Equal(t, manifestID, request.GetManifestId())
+			assert.Equal(t, path, request.GetRemovePath())
+			return &v1.SimpleStatusResponse{Status: expectedStatus}, nil
+		}))
+
+	SetViper(t, "agent.port", port)
+
+	manifestIDString := strconv.FormatInt(int64(manifestID), 10)
+
+	tests := []struct {
+		scenario string
+		args     []string
+	}{
+		{"short form", []string{"-m", manifestIDString, path}},
+		{"long form", []string{"--manifest_id", manifestIDString, path}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.scenario, func(t *testing.T) {
+			removeCmd := NewRemoveCmd()
+			removeCmd.SetArgs(tt.args)
+			require.NoError(t, removeCmd.Execute())
+		})
+	}
+
+}
+
+type removeFromManifestFunc func(ctx context.Context, request *v1.RemoveFromManifestRequest) (*v1.SimpleStatusResponse, error)
+
+type mockRemoveFromManifest struct {
+	v1.UnimplementedAgentServer
+	f removeFromManifestFunc
+}
+
+func newMockRemoveFromManifest(f removeFromManifestFunc) mockRemoveFromManifest {
+	return mockRemoveFromManifest{f: f}
+}
+
+func (m mockRemoveFromManifest) RemoveFromManifest(ctx context.Context, req *v1.RemoveFromManifestRequest) (*v1.SimpleStatusResponse, error) {
+	if m.f == nil {
+		panic("mock RemoveFromManifest function not set")
+	}
+	return m.f(ctx, req)
+}
+
+func SetViper(t *testing.T, key string, value any) {
+	old := viper.Get(key)
+	t.Cleanup(func() {
+		viper.Set(key, old)
+	})
+	viper.Set(key, value)
+}
+
+// StartMockGRPC starts a GPRC server that registers mock as the v1.AgentServer
+// Server and listener Close() are registered to t's Cleanup() method.
+func StartMockGRPC(t *testing.T, mock v1.AgentServer) (port string) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		lis.Close()
+	})
+
+	_, port, err = net.SplitHostPort(lis.Addr().String())
+	require.NoError(t, err)
+
+	s := grpc.NewServer()
+	t.Cleanup(func() {
+		s.Stop()
+	})
+	s.RegisterService(&v1.Agent_ServiceDesc, mock)
+	go func() {
+		err := s.Serve(lis)
+		assert.NoError(t, err)
+	}()
+
+	return
+}

--- a/pkg/models/manifestFile.go
+++ b/pkg/models/manifestFile.go
@@ -1,0 +1,6 @@
+package models
+
+type RemoveFromManifestResponse struct {
+	Deleted int64
+	Updated int64
+}

--- a/pkg/server/manifest.go
+++ b/pkg/server/manifest.go
@@ -151,12 +151,14 @@ func (s *agentServer) AddToManifest(ctx context.Context, request *pb.AddToManife
 // RemoveFromManifest removes one or more files from the index for an existing manifest.
 func (s *agentServer) RemoveFromManifest(ctx context.Context, request *pb.RemoveFromManifestRequest) (*pb.SimpleStatusResponse, error) {
 
-	err := s.ManifestService().RemoveFromManifest(request.ManifestId, request.RemovePath)
+	removeResp, err := s.ManifestService().RemoveFromManifest(request.ManifestId, request.RemovePath)
 	if err != nil {
 		return nil, err
 	}
 
-	response := pb.SimpleStatusResponse{Status: "Successfully removed files."}
+	removeStatus := fmt.Sprintf("Successfully removed %d %s files and %d %s files.", removeResp.Deleted, manifestFile.Local, removeResp.Updated, manifestFile.Registered)
+
+	response := pb.SimpleStatusResponse{Status: removeStatus}
 	return &response, nil
 }
 

--- a/pkg/server/manifest.go
+++ b/pkg/server/manifest.go
@@ -156,7 +156,10 @@ func (s *agentServer) RemoveFromManifest(ctx context.Context, request *pb.Remove
 		return nil, err
 	}
 
-	removeStatus := fmt.Sprintf("Successfully removed %d %s files and %d %s files.", removeResp.Deleted, manifestFile.Local, removeResp.Updated, manifestFile.Registered)
+	// using uppercase status strings because that's how the user sees them via the CLI manifest list.
+	removeStatus := fmt.Sprintf("Successfully removed %d %s files and %d %s files.",
+		removeResp.Deleted, strings.ToUpper(manifestFile.Local.String()),
+		removeResp.Updated, strings.ToUpper(manifestFile.Registered.String()))
 
 	response := pb.SimpleStatusResponse{Status: removeStatus}
 	return &response, nil

--- a/pkg/service/manifest.go
+++ b/pkg/service/manifest.go
@@ -85,7 +85,7 @@ func (s *ManifestService) Add(params store.ManifestParams) (*store.Manifest, err
 	return s.mStore.Add(params)
 }
 
-func (s *ManifestService) RemoveFromManifest(manifestId int32, removePath string) error {
+func (s *ManifestService) RemoveFromManifest(manifestId int32, removePath string) (models.RemoveFromManifestResponse, error) {
 	return s.mfStore.RemoveFromManifest(manifestId, removePath)
 }
 

--- a/pkg/store/manifestFile_test.go
+++ b/pkg/store/manifestFile_test.go
@@ -1,0 +1,278 @@
+package store
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/manifest/manifestFile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestManifestFileStore(t *testing.T) {
+	tests := []struct {
+		scenario string
+		fixture  Fixture
+		testFunc func(t *testing.T, fixture *Fixture)
+	}{
+		{"remove from manifest: no manifest found", removeFromManifestFixture, testRemoveFromManifestNoManifest},
+		{"remove from manifest: none found", removeFromManifestFixture, testRemoveFromManifestNoFilesUnderPrefix},
+		{"remove from manifest: one found", removeFromManifestFixture, testRemoveFromManifestOneFileUnderPrefix},
+		{"remove from manifest: multiple files under prefix", removeFromManifestFixture, testRemoveFromManifestMultipleFilesUnderPrefix},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.scenario, func(t *testing.T) {
+			fixture := &tt.fixture
+			fixture.Setup(t)
+
+			t.Cleanup(func() {
+				fixture.Teardown(t)
+			})
+
+			tt.testFunc(t, fixture)
+		})
+	}
+}
+
+var removeFromManifestFixture = Fixture{
+	ManifestParams: ManifestParams{
+		UserId:           uuid.NewString(),
+		UserName:         uuid.NewString(),
+		OrganizationId:   uuid.NewString(),
+		OrganizationName: uuid.NewString(),
+		DatasetId:        uuid.NewString(),
+		DatasetName:      uuid.NewString(),
+	},
+	ManifestFiles: []ManifestFile{
+		{
+			SourcePath: "/home/user/folder1/local.txt",
+			TargetPath: "folder1",
+			TargetName: "local.txt",
+			UploadId:   uuid.New(),
+			Status:     manifestFile.Local,
+		},
+		{
+			SourcePath: "/home/user/folder1/registered.txt",
+			TargetPath: "folder1",
+			TargetName: "registered.txt",
+			UploadId:   uuid.New(),
+			Status:     manifestFile.Registered,
+		},
+		{
+			SourcePath: "/home/user/folder1/finalized.txt",
+			TargetPath: "folder1",
+			TargetName: "finalized.txt",
+			UploadId:   uuid.New(),
+			Status:     manifestFile.Finalized,
+		},
+		{
+			SourcePath: "/home/user/folder2/local1.txt",
+			TargetPath: "folder2",
+			TargetName: "local1.txt",
+			UploadId:   uuid.New(),
+			Status:     manifestFile.Local,
+		},
+		{
+			SourcePath: "/home/user/folder2/local2.txt",
+			TargetPath: "folder2",
+			TargetName: "local2.txt",
+			UploadId:   uuid.New(),
+			Status:     manifestFile.Local,
+		},
+	},
+}
+
+func testRemoveFromManifestNoManifest(t *testing.T, fixture *Fixture) {
+	resp, err := fixture.ManifestFileStore.RemoveFromManifest(fixture.Manifest.Id+1000, "/path/to/remove")
+	require.NoError(t, err)
+
+	assert.Equal(t, resp.Deleted, int64(0))
+	assert.Equal(t, resp.Updated, int64(0))
+
+	var expectedSourcePaths []string
+	for _, file := range fixture.ManifestFiles {
+		expectedSourcePaths = append(expectedSourcePaths, file.SourcePath)
+	}
+
+	assertions := []ManifestFilesAssertion{ManifestFilesLenAssertion(len(fixture.ManifestFiles))}
+	for _, file := range fixture.ManifestFiles {
+		assertions = append(assertions, ManifestFilesContainsSourcePathAndStatusAssertion(file.SourcePath, file.Status))
+	}
+
+	// all files should still be in the manifest with the same status
+	fixture.AssertManifestFiles(t, assertions...)
+}
+
+func testRemoveFromManifestNoFilesUnderPrefix(t *testing.T, fixture *Fixture) {
+	resp, err := fixture.ManifestFileStore.RemoveFromManifest(fixture.Manifest.Id, "/home/user/folder3/")
+	require.NoError(t, err)
+
+	assert.Equal(t, resp.Deleted, int64(0))
+	assert.Equal(t, resp.Updated, int64(0))
+
+	assertions := []ManifestFilesAssertion{ManifestFilesLenAssertion(len(fixture.ManifestFiles))}
+	for _, file := range fixture.ManifestFiles {
+		assertions = append(assertions, ManifestFilesContainsSourcePathAndStatusAssertion(file.SourcePath, file.Status))
+	}
+
+	// all files should still be in the manifest with the same status
+	fixture.AssertManifestFiles(t, assertions...)
+}
+
+func testRemoveFromManifestOneFileUnderPrefix(t *testing.T, fixture *Fixture) {
+	prefixToRemove := "/home/user/folder1/local.txt"
+	resp, err := fixture.ManifestFileStore.RemoveFromManifest(fixture.Manifest.Id, prefixToRemove)
+	require.NoError(t, err)
+
+	assert.Equal(t, resp.Deleted, int64(1))
+	assert.Equal(t, resp.Updated, int64(0))
+
+	assertions := []ManifestFilesAssertion{
+		// all but one file should remain
+		ManifestFilesLenAssertion(len(fixture.ManifestFiles) - 1),
+		// remaining files should be unchanged
+		ManifestFilesContainsSourcePathAndStatusAssertion("/home/user/folder1/registered.txt", manifestFile.Registered),
+		ManifestFilesContainsSourcePathAndStatusAssertion("/home/user/folder1/finalized.txt", manifestFile.Finalized),
+		ManifestFilesContainsSourcePathAndStatusAssertion("/home/user/folder2/local1.txt", manifestFile.Local),
+		ManifestFilesContainsSourcePathAndStatusAssertion("/home/user/folder2/local2.txt", manifestFile.Local),
+	}
+
+	fixture.AssertManifestFiles(t, assertions...)
+
+}
+
+func testRemoveFromManifestMultipleFilesUnderPrefix(t *testing.T, fixture *Fixture) {
+	prefixToRemove := "/home/user/folder1/"
+	resp, err := fixture.ManifestFileStore.RemoveFromManifest(fixture.Manifest.Id, prefixToRemove)
+	require.NoError(t, err)
+
+	assert.Equal(t, resp.Deleted, int64(1))
+	assert.Equal(t, resp.Updated, int64(1))
+
+	assertions := []ManifestFilesAssertion{
+		// all but one file should remain
+		ManifestFilesLenAssertion(len(fixture.ManifestFiles) - 1),
+		// registered file with matching source path should be changed to Removed
+		ManifestFilesContainsSourcePathAndStatusAssertion("/home/user/folder1/registered.txt", manifestFile.Removed),
+		// remaining files should be unchanged
+		ManifestFilesContainsSourcePathAndStatusAssertion("/home/user/folder1/finalized.txt", manifestFile.Finalized),
+		ManifestFilesContainsSourcePathAndStatusAssertion("/home/user/folder2/local1.txt", manifestFile.Local),
+		ManifestFilesContainsSourcePathAndStatusAssertion("/home/user/folder2/local2.txt", manifestFile.Local),
+	}
+
+	fixture.AssertManifestFiles(t, assertions...)
+
+}
+
+type Fixture struct {
+	// Stores
+	ManifestStore     *manifestStore
+	ManifestFileStore *manifestFileStore
+
+	//Inputs
+	ManifestParams ManifestParams
+
+	//Input and Output
+	ManifestFiles []ManifestFile
+
+	//Outputs
+	Manifest *Manifest
+}
+
+func (f *Fixture) Setup(t *testing.T) {
+	f.ManifestStore = NewManifestStore(db)
+	f.ManifestFileStore = NewManifestFileStore(db)
+
+	manifest, err := f.ManifestStore.Add(f.ManifestParams)
+	require.NoError(t, err)
+	f.Manifest = manifest
+
+	f.addManifestFiles(t, f.Manifest.Id)
+
+}
+
+func (f *Fixture) addManifestFiles(t *testing.T, manifestID int32) {
+	if len(f.ManifestFiles) == 0 {
+		return
+	}
+	var uploadIDToFile = make(map[string]*ManifestFile, len(f.ManifestFiles))
+	currentTime := time.Now()
+	const rowSQL = "(?, ?, ?, ?, ?, ?, ?, ?)"
+	var vals []interface{}
+	var inserts []string
+
+	sqlInsert := `INSERT INTO manifest_files(source_path, target_path, target_name, upload_id, manifest_id, status, created_at, updated_at) VALUES `
+	for i := range f.ManifestFiles {
+		file := &f.ManifestFiles[i]
+		file.ManifestId = manifestID
+		uploadID := file.UploadId.String()
+		uploadIDToFile[uploadID] = file
+		inserts = append(inserts, rowSQL)
+		createdAt, updatedAt := file.CreatedAt, file.UpdatedAt
+		if createdAt.IsZero() {
+			createdAt = currentTime
+		}
+		if updatedAt.IsZero() {
+			updatedAt = currentTime
+		}
+		vals = append(vals, file.SourcePath, file.TargetPath, file.TargetName, uploadID, file.ManifestId,
+			file.Status.String(), createdAt, updatedAt)
+	}
+	fullInsert := fmt.Sprintf("%s %s RETURNING upload_id, id", sqlInsert, strings.Join(inserts, ", "))
+
+	stmt, err := db.Prepare(fullInsert)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, stmt.Close()) }()
+
+	rows, err := stmt.Query(vals...)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, rows.Close()) }()
+
+	//SQLite makes no guarantee about the order of the returned rows so can't assume first id goes with first manifest file.
+	// https://www.sqlite.org/lang_returning.html
+	for rows.Next() {
+		var id int32
+		var uploadID string
+		require.NoError(t, rows.Scan(&uploadID, &id))
+		file, found := uploadIDToFile[uploadID]
+		require.True(t, found)
+		file.Id = id
+	}
+
+}
+
+func (f *Fixture) Teardown(t *testing.T) {
+	require.NoError(t, f.ManifestStore.Remove(f.Manifest.Id))
+}
+
+type ManifestFilesAssertion func(t *testing.T, actualManifestFiles []ManifestFile)
+
+func ManifestFilesLenAssertion(expectedLen int) ManifestFilesAssertion {
+	return func(t *testing.T, actualManifestFiles []ManifestFile) {
+		assert.Len(t, actualManifestFiles, expectedLen, "expected %d files, found %d: %+v", expectedLen, len(actualManifestFiles), actualManifestFiles)
+	}
+}
+
+func ManifestFilesContainsSourcePathAndStatusAssertion(expectedSourcePath string, expectedStatus manifestFile.Status) ManifestFilesAssertion {
+	return func(t *testing.T, actualManifestFiles []ManifestFile) {
+		actualIndex := slices.IndexFunc(actualManifestFiles, func(file ManifestFile) bool {
+			return file.SourcePath == expectedSourcePath && file.Status == expectedStatus
+		})
+		require.True(t, actualIndex > -1, "no file with expected source path %s and status %s found", expectedSourcePath, expectedStatus.String())
+	}
+}
+
+// AssertManifestFiles runs the given assertions over all the files that exist under the Fixture's manifest in the DB
+// Assumes no manifest files were added except Fixture.ManifestFiles.
+func (f *Fixture) AssertManifestFiles(t *testing.T, assertions ...ManifestFilesAssertion) {
+	files, err := f.ManifestFileStore.Get(f.Manifest.Id, int32(len(f.ManifestFiles)), 0)
+	require.NoError(t, err)
+
+	for _, assertion := range assertions {
+		assertion(t, files)
+	}
+}


### PR DESCRIPTION
PR updates the help and output messages for the `pennsieve manifest remove` command to correctly reflect the arguments and results.

PR makes help:
```
 % ./pennsieve-agent manifest remove --help
Removes files from an existing manifest.
This command will remove any files that have a source path starting with SOURCE-PATH-PREFIX and having status LOCAL from the given manifest.
If a file in the manifest has a source path starting with SOURCE-PATH-PREFIX and status REGISTERED, then the status will be updated to REMOVED.

Usage:
  pennsieve manifest remove -m MANIFEST-ID SOURCE-PATH-PREFIX [flags]

Flags:
  -h, --help                help for remove
  -m, --manifest_id int32   Manifest id

Global Flags:
      --config string   config file (default is $HOME/.pennsieve/config.ini)
```

PR updates the output to show the number of files actually removed, or updated:
```
% ./pennsieve-agent manifest list -f 56
+------------------------------------------------------------------------------------------------------------------------------------+
| Files for upload manifest: 56                                                                                                      |
+--------+--------------------------------------+-------------------------------------------------------------+-------------+--------+
|     ID | UPLOAD ID                            | SOURCE PATH                                                 | TARGET PATH | STATUS |
+--------+--------------------------------------+-------------------------------------------------------------+-------------+--------+
| 245884 | 8da011b6-268b-4b68-a669-795ff7e4751a | /Users/johnfr/Documents/test_edf_w_ini/doc1-copy3.pdf       |             |  LOCAL |
| 245885 | 7d23c331-21b8-4df9-bf4f-3611e26af020 | /Users/johnfr/Documents/test_edf_w_ini/doc1-copy4.pdf       |             |  LOCAL |
| 245886 | abf5b1a5-e62e-4b8f-a838-2b1b935df092 | /Users/johnfr/Documents/test_edf_w_ini/doc1.pdf             |             |  LOCAL |
| 245887 | 7091e9e0-ac47-4036-8542-cd4ac8ac2792 | /Users/johnfr/Documents/test_edf_w_ini/doc2.pdf             |             |  LOCAL |
| 245888 | 666038f5-d163-4f8c-9544-75b3b987a517 | /Users/johnfr/Documents/test_edf_w_ini/files.zip            |             |  LOCAL |
| 245889 | 585de9e0-9145-4f46-946c-fec51a2d68d5 | /Users/johnfr/Documents/test_edf_w_ini/ieeg-dataset.ini     |             |  LOCAL |
| 245890 | cb07adc8-4917-42af-bc8f-f7170cb15446 | /Users/johnfr/Documents/test_edf_w_ini/test_generator_2.edf |             |  LOCAL |
+--------+--------------------------------------+-------------------------------------------------------------+-------------+--------+
johnfr@Johns-MacBook-Pro-48 pennsieve-agent % ./pennsieve-agent manifest remove -m 56  /Users/johnfr/Documents/test_edf_w_ini/doc     
manifest id: 56
source path prefix: /Users/johnfr/Documents/test_edf_w_ini/doc
Successfully removed 4 LOCAL files and 0 REGISTERED files.
johnfr@Johns-MacBook-Pro-48 pennsieve-agent % ./pennsieve-agent manifest list -f 56                                              
+------------------------------------------------------------------------------------------------------------------------------------+
| Files for upload manifest: 56                                                                                                      |
+--------+--------------------------------------+-------------------------------------------------------------+-------------+--------+
|     ID | UPLOAD ID                            | SOURCE PATH                                                 | TARGET PATH | STATUS |
+--------+--------------------------------------+-------------------------------------------------------------+-------------+--------+
| 245888 | 666038f5-d163-4f8c-9544-75b3b987a517 | /Users/johnfr/Documents/test_edf_w_ini/files.zip            |             |  LOCAL |
| 245889 | 585de9e0-9145-4f46-946c-fec51a2d68d5 | /Users/johnfr/Documents/test_edf_w_ini/ieeg-dataset.ini     |             |  LOCAL |
| 245890 | cb07adc8-4917-42af-bc8f-f7170cb15446 | /Users/johnfr/Documents/test_edf_w_ini/test_generator_2.edf |             |  LOCAL |
+--------+--------------------------------------+-------------------------------------------------------------+-------------+--------+
```

Includes some small refactors of the remove `cobra.Command` to allow for writing tests.

https://app.clickup.com/t/868ex02qr