### PR TITLE
Remove the install dependencies step from *-release jobs.

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -105,10 +105,6 @@ jobs:
         run: go mod download
       - name: Go Mod Verify
         run: go mod verify
-      - name: Install dependencies
-        run: |
-          go version
-          go get -u golang.org/x/lint/golint
       - name: Build release
         id: build-release
         run: |
@@ -179,10 +175,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-      - name: Install dependencies
-        run: |
-          go version
-          go get -u golang.org/x/lint/golint
       - name: Build release
         id: build-release
         run: |
@@ -250,10 +242,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-      - name: Install dependencies
-        run: |
-          go version
-          go get -u golang.org/x/lint/golint
       - name: Build release
         id: build-release
         run: |
@@ -373,10 +361,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-      - name: Install dependencies
-        run: |
-          go version
-          go get -u golang.org/x/lint/golint
       - name: Build release
         id: build-release
         run: |


### PR DESCRIPTION
Removes the `Install dependencies` step from `linux-release`,  `windows-release`, `mac-arm64-release`, and `mac-x86_64-release` jobs in `publish-release.yml`. 

This step in those jobs only runs go version and installs golint which is a deprecated package and not used in the remaining steps.