### PR TITLE
Fix file download path

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ for Python, use:
 make compile-python
 ```
 
+### Requires installation of the following:
+**protoc**, **protoc-gen-go**, **protoc-gen-go-grpc**
+
+MacOS with [Homebrew](https://brew.sh/)
+```
+brew install protobuf
+brew install protoc-gen-go
+brew install protoc-gen-go-grpc
+```
+
 ## Pennsieve Configuration File
 The CLI depends on a configuration file in the ~/.pennsieve folder. You can initialize this file 
 with the ```pennsieve-agent config wizard``` command. 

--- a/pkg/shared/download.go
+++ b/pkg/shared/download.go
@@ -92,7 +92,7 @@ func (s *downloader) DownloadWorker(ctx context.Context, workerId int,
             log.Error("Cannot find file in returned presigned url array")
         }
 
-        fileLocation := filepath.Join(targetFolder, record.FileName.String)
+        fileLocation := filepath.Join(targetFolder, record.Path, record.FileName.String)
         _, err = s.DownloadFileFromPresignedUrl(ctx, preURL, fileLocation, record.PackageNodeId)
         if err != nil {
             log.Errorf("Download failed: %v", err)


### PR DESCRIPTION
Fixes [Pennsieve Agent downloads all dataset files to target folder](https://app.clickup.com/t/868hazfz4)

The correction is to include the `record.Path` value when making the download file location:
- [pkg/shared/download.go](https://github.com/Pennsieve/pennsieve-agent/pull/73/changes#diff-858172f16b4cfa8cd5e1b5eaf294542474d754df425b6c26ace8810ebe2a942fR95)
```go
        fileLocation := filepath.Join(targetFolder, record.Path, record.FileName.String)
```