### PR TITLE
868g9upnw upgrade pennsieve-go-core v1.13.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.5.9
 	github.com/mattn/go-sqlite3 v1.14.23
 	github.com/pennsieve/pennsieve-go v1.3.11
-	github.com/pennsieve/pennsieve-go-core v1.13.3
+	github.com/pennsieve/pennsieve-go-core v1.13.7
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -125,14 +125,10 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
-github.com/pennsieve/pennsieve-go v1.3.9 h1:BkPPlWDCXE/zOUbLsEw+7riB+pLmc01dGWp5UW1VC5g=
-github.com/pennsieve/pennsieve-go v1.3.9/go.mod h1:9HpyaoXalqGjLt8+z7PsObsrdmMDlgs4YDxxlFExQKo=
-github.com/pennsieve/pennsieve-go v1.3.10 h1:7KJPvOksY1eOL1mIOgqSLAqlHJ9zl9ctIoqnuP9VOqw=
-github.com/pennsieve/pennsieve-go v1.3.10/go.mod h1:9HpyaoXalqGjLt8+z7PsObsrdmMDlgs4YDxxlFExQKo=
 github.com/pennsieve/pennsieve-go v1.3.11 h1:HX7oRVZM1cp+ubwfSVDECihDdKGdXu7QWZ4Ri3CxxHA=
 github.com/pennsieve/pennsieve-go v1.3.11/go.mod h1:9HpyaoXalqGjLt8+z7PsObsrdmMDlgs4YDxxlFExQKo=
-github.com/pennsieve/pennsieve-go-core v1.13.3 h1:bdk07K6KnHuphDswWjSSxqvTyRDHbFfFIXGglFQeBHw=
-github.com/pennsieve/pennsieve-go-core v1.13.3/go.mod h1:MeMDPuGOXkY8q+opOES8r7ib3EAt5dveB+PMjgtLNKM=
+github.com/pennsieve/pennsieve-go-core v1.13.7 h1:chscmBoATCkqvWakkcbvvia4Vx1WnwDe7wXboL4Huq4=
+github.com/pennsieve/pennsieve-go-core v1.13.7/go.mod h1:MeMDPuGOXkY8q+opOES8r7ib3EAt5dveB+PMjgtLNKM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Description
**ClickUp Ticket:** [868g9upnw](https://app.clickup.com/t/868g9upnw)
**Related PR:** https://github.com/Pennsieve/pennsieve-go-core/pull/45