### PR TITLE
Remove fail from --on-conflict + bump SDK v1.6.1

### DIFF
--- a/api/v1/agent.pb.go
+++ b/api/v1/agent.pb.go
@@ -2217,9 +2217,9 @@ type UploadManifestRequest struct {
 	ManifestId int32 `protobuf:"varint,1,opt,name=manifest_id,json=manifestId,proto3" json:"manifest_id,omitempty"`
 	// on_conflict controls server-side name-collision resolution during
 	// finalize. Accepted values: "keepBoth" (default, auto-rename new
-	// upload to " (N)"), "replace" (soft-delete predecessor and record
-	// provenance), "fail" (abort with an error listing conflicts).
-	// Empty string is treated as "keepBoth" for backward compatibility.
+	// upload to " (N)") or "replace" (soft-delete predecessor and record
+	// provenance). Empty string is treated as "keepBoth" for backward
+	// compatibility.
 	OnConflict string `protobuf:"bytes,2,opt,name=on_conflict,json=onConflict,proto3" json:"on_conflict,omitempty"`
 }
 

--- a/api/v1/agent.proto
+++ b/api/v1/agent.proto
@@ -323,9 +323,9 @@ message UploadManifestRequest{
 	int32 manifest_id = 1;
 	// on_conflict controls server-side name-collision resolution during
 	// finalize. Accepted values: "keepBoth" (default, auto-rename new
-	// upload to " (N)"), "replace" (soft-delete predecessor and record
-	// provenance), "fail" (abort with an error listing conflicts).
-	// Empty string is treated as "keepBoth" for backward compatibility.
+	// upload to " (N)") or "replace" (soft-delete predecessor and record
+	// provenance). Empty string is treated as "keepBoth" for backward
+	// compatibility.
 	string on_conflict = 2;
 }
 

--- a/cmd/upload/manifest.go
+++ b/cmd/upload/manifest.go
@@ -64,10 +64,10 @@ var ManifestCmd = &cobra.Command{
 
 		onConflict, _ := cmd.Flags().GetString("on-conflict")
 		switch onConflict {
-		case "", "keepBoth", "replace", "fail":
+		case "", "keepBoth", "replace":
 			// valid
 		default:
-			log.Printf("Error: --on-conflict must be one of: keepBoth, replace, fail (got %q)", onConflict)
+			log.Printf("Error: --on-conflict must be one of: keepBoth, replace (got %q)", onConflict)
 			return
 		}
 		WrkFlwReq := api.StartWorkflowRequest{

--- a/cmd/upload/upload.go
+++ b/cmd/upload/upload.go
@@ -37,7 +37,7 @@ func init() {
 	ManifestCmd.Flags().String("workflow", "", "Add a workflow to the upload process")
 	ManifestCmd.Flags().String("workflowOpts", "", "Pass in workflow options")
 	// on-conflict controls server-side name-collision resolution during
-	// finalize. Values: keepBoth (default) | replace | fail. Empty == keepBoth.
-	ManifestCmd.Flags().String("on-conflict", "", "How to resolve name collisions with existing packages: keepBoth (default), replace, or fail")
+	// finalize. Values: keepBoth (default) | replace. Empty == keepBoth.
+	ManifestCmd.Flags().String("on-conflict", "", "How to resolve name collisions with existing packages: keepBoth (default) or replace")
 
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.5.9
 	github.com/mattn/go-sqlite3 v1.14.23
-	github.com/pennsieve/pennsieve-go v1.6.0
+	github.com/pennsieve/pennsieve-go v1.6.1
 	github.com/pennsieve/pennsieve-go-core v1.13.7
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/pennsieve/pennsieve-go v1.5.2-0.20260420142605-731ef4935321 h1:1kRlhc
 github.com/pennsieve/pennsieve-go v1.5.2-0.20260420142605-731ef4935321/go.mod h1:0az9SS38LICH2ejbTDQA/C0CgIr7f7K7zupb4KF7v2A=
 github.com/pennsieve/pennsieve-go v1.6.0 h1:pzyoN6Nh9gvCRHop7ZCAnRVMYV2eVaAFxR2LmAQ7Jqk=
 github.com/pennsieve/pennsieve-go v1.6.0/go.mod h1:0az9SS38LICH2ejbTDQA/C0CgIr7f7K7zupb4KF7v2A=
+github.com/pennsieve/pennsieve-go v1.6.1 h1:BFH1VI5hpRq8dY/YuUXRPqN1F4UuZsq0rpJfhhRgAvw=
+github.com/pennsieve/pennsieve-go v1.6.1/go.mod h1:0az9SS38LICH2ejbTDQA/C0CgIr7f7K7zupb4KF7v2A=
 github.com/pennsieve/pennsieve-go-core v1.13.7 h1:chscmBoATCkqvWakkcbvvia4Vx1WnwDe7wXboL4Huq4=
 github.com/pennsieve/pennsieve-go-core v1.13.7/go.mod h1:MeMDPuGOXkY8q+opOES8r7ib3EAt5dveB+PMjgtLNKM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Companion to upload-service-v2 cleanup. CLI rejects `--on-conflict fail` locally; server rejects server-side too. Proto doc + Go bindings regenerated. Targets `feature_direct_to_storage` per the existing agent branching convention.