### PR TITLE
Add pkg/cloud: registration + WebSocket client for pennsieve-agent-service

### DIFF
--- a/db/migrations/000003_create_cloud_tables.down.sql
+++ b/db/migrations/000003_create_cloud_tables.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_cloud_command_status;
+DROP TABLE IF EXISTS cloud_command;
+DROP TABLE IF EXISTS cloud_registration;
+DROP TABLE IF EXISTS cloud_installation;

--- a/db/migrations/000003_create_cloud_tables.up.sql
+++ b/db/migrations/000003_create_cloud_tables.up.sql
@@ -1,0 +1,35 @@
+-- Local installation identity (one row per host).
+CREATE TABLE IF NOT EXISTS cloud_installation (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    installation_id TEXT UNIQUE NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+-- Per-profile registration with the Pennsieve Agent Service.
+-- profile_name maps to the active Viper profile in config.ini.
+CREATE TABLE IF NOT EXISTS cloud_registration (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    profile_name TEXT UNIQUE NOT NULL,
+    agent_id TEXT NOT NULL,
+    agent_secret TEXT NOT NULL,
+    ws_url TEXT NOT NULL,
+    ws_token_url TEXT NOT NULL,
+    heartbeat_sec INTEGER NOT NULL DEFAULT 270,
+    registered_at INTEGER NOT NULL
+);
+
+-- Server-issued commands. The agent persists these locally so it can
+-- reconcile state with the service after a crash or reconnect.
+CREATE TABLE IF NOT EXISTS cloud_command (
+    command_id TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    status TEXT NOT NULL,
+    received_at INTEGER NOT NULL,
+    started_at INTEGER,
+    completed_at INTEGER,
+    result TEXT,
+    error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_cloud_command_status ON cloud_command(status);

--- a/pkg/cloud/client.go
+++ b/pkg/cloud/client.go
@@ -1,0 +1,102 @@
+package cloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client is a thin REST client for the Pennsieve Agent Service. It is
+// deliberately minimal: registration, ws-token exchange, and
+// reconciliation. WebSocket transport is in ws.go.
+type Client struct {
+	BaseURL string
+	HTTP    *http.Client
+
+	// JWT is the user's Pennsieve session token, used for endpoints
+	// that require user authentication (registration, reconcile).
+	// Empty when calling unauthenticated endpoints (ws-token).
+	JWT string
+}
+
+func NewClient(baseURL, jwt string) *Client {
+	return &Client{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		HTTP:    &http.Client{Timeout: 30 * time.Second},
+		JWT:     jwt,
+	}
+}
+
+func (c *Client) Register(ctx context.Context, req RegisterRequest) (RegisterResponse, error) {
+	var out RegisterResponse
+	err := c.doJSON(ctx, http.MethodPost, "/agents/register", req, &out, true)
+	return out, err
+}
+
+func (c *Client) WSToken(ctx context.Context, req WSTokenRequest) (WSTokenResponse, error) {
+	var out WSTokenResponse
+	err := c.doJSON(ctx, http.MethodPost, "/agents/ws-token", req, &out, false)
+	return out, err
+}
+
+type ReconcileCommandView struct {
+	CommandId string `json:"commandId"`
+	Status    string `json:"status"`
+}
+
+type ReconcileRequest struct {
+	AgentId  string                 `json:"agentId"`
+	Commands []ReconcileCommandView `json:"commands"`
+}
+
+type ReconcileResponse struct {
+	Outstanding []OutstandingCommand `json:"outstanding"`
+}
+
+type OutstandingCommand struct {
+	CommandId string          `json:"commandId"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+func (c *Client) Reconcile(ctx context.Context, agentId string, req ReconcileRequest) (ReconcileResponse, error) {
+	var out ReconcileResponse
+	err := c.doJSON(ctx, http.MethodPost, "/agents/"+agentId+"/reconcile", req, &out, true)
+	return out, err
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path string, in, out any, authed bool) error {
+	body, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if authed {
+		if c.JWT == "" {
+			return fmt.Errorf("cloud: %s requires JWT", path)
+		}
+		req.Header.Set("Authorization", "Bearer "+c.JWT)
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("cloud: %s %s: %s: %s", method, path, resp.Status, string(b))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/pkg/cloud/client_test.go
+++ b/pkg/cloud/client_test.go
@@ -1,0 +1,84 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newServer(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL, "JWT"), srv
+}
+
+func TestClient_Register(t *testing.T) {
+	c, _ := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/agents/register", r.URL.Path)
+		assert.Equal(t, "Bearer JWT", r.Header.Get("Authorization"))
+		var req RegisterRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "inst-1", req.InstallationId)
+		_ = json.NewEncoder(w).Encode(RegisterResponse{
+			AgentId: "a1", AgentSecret: "s1", WSURL: "wss://x", HeartbeatSec: 270,
+		})
+	})
+
+	resp, err := c.Register(context.Background(), RegisterRequest{InstallationId: "inst-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "a1", resp.AgentId)
+	assert.Equal(t, "s1", resp.AgentSecret)
+}
+
+func TestClient_Register_RequiresJWT(t *testing.T) {
+	c := NewClient("http://example", "")
+	_, err := c.Register(context.Background(), RegisterRequest{InstallationId: "x"})
+	require.Error(t, err)
+}
+
+func TestClient_WSToken_NoJWT(t *testing.T) {
+	// /agents/ws-token does NOT require the user JWT.
+	c, _ := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"), "ws-token must not require user auth")
+		_ = json.NewEncoder(w).Encode(WSTokenResponse{Token: "tok", ExpiresAt: 1})
+	})
+	c.JWT = "" // even without JWT this works
+	resp, err := c.WSToken(context.Background(), WSTokenRequest{AgentId: "a", AgentSecret: "s"})
+	require.NoError(t, err)
+	assert.Equal(t, "tok", resp.Token)
+}
+
+func TestClient_Reconcile(t *testing.T) {
+	c, _ := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/agents/a1/reconcile", r.URL.Path)
+		var req ReconcileRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "a1", req.AgentId)
+		_ = json.NewEncoder(w).Encode(ReconcileResponse{
+			Outstanding: []OutstandingCommand{
+				{CommandId: "c1", Type: "ping", Payload: json.RawMessage(`{}`)},
+			},
+		})
+	})
+	resp, err := c.Reconcile(context.Background(), "a1", ReconcileRequest{AgentId: "a1"})
+	require.NoError(t, err)
+	require.Len(t, resp.Outstanding, 1)
+	assert.Equal(t, "c1", resp.Outstanding[0].CommandId)
+}
+
+func TestClient_NonOK(t *testing.T) {
+	c, _ := newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "denied")
+	})
+	_, err := c.Register(context.Background(), RegisterRequest{InstallationId: "x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}

--- a/pkg/cloud/dialer.go
+++ b/pkg/cloud/dialer.go
@@ -1,0 +1,26 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+)
+
+// defaultDialer is the production Dialer. It is a thin shim around
+// the chosen WebSocket library and is intentionally separated from
+// the WSClient so tests can substitute a fake without dragging the
+// real network library into the test build.
+//
+// To keep the dependency footprint of pkg/cloud minimal until the
+// websocket library choice is finalized at the project level, this
+// default dialer is a placeholder: it returns an error if used. To
+// activate WebSocket connectivity, plug in a concrete Dialer at
+// Manager construction time (see WSClientConfig.Dialer in ws.go).
+//
+// The recommended production library is github.com/coder/websocket
+// (the maintained successor to nhooyr.io/websocket); a one-file
+// adapter that satisfies the WSConn interface is straightforward.
+type defaultDialer struct{}
+
+func (defaultDialer) Dial(ctx context.Context, wsURL, token string) (WSConn, error) {
+	return nil, fmt.Errorf("cloud: no WebSocket dialer configured; supply WSClientConfig.Dialer")
+}

--- a/pkg/cloud/json.go
+++ b/pkg/cloud/json.go
@@ -1,0 +1,5 @@
+package cloud
+
+import "encoding/json"
+
+var jsonMarshal = json.Marshal

--- a/pkg/cloud/manager.go
+++ b/pkg/cloud/manager.go
@@ -1,0 +1,241 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Manager orchestrates registration with the Pennsieve Agent Service
+// and maintains a WebSocket connection for the active profile.
+//
+// Workflow:
+//   - On Start: ensure local installation id exists, register the
+//     active profile (mints agentId+agentSecret on first run, refreshes
+//     on subsequent runs), then connect the WS client.
+//   - On profile switch: stop the WS client, register the new profile,
+//     start a fresh WS client.
+//
+// The agent can talk to the platform via SendEvent (out-of-band agent->
+// server messages) and respond to inbound commands by registering
+// handlers on the Manager.
+type Manager struct {
+	store   *Store
+	rest    *Client
+	wsCli   *WSClient
+	profile string
+	reg     Registration
+	inst    Installation
+
+	hostname string
+	osName   string
+	version  string
+
+	// Optional overrides — primarily for tests. If nil, the default
+	// (production) implementations are used.
+	Dialer      Dialer
+	TokenSource TokenSource
+
+	handlers map[string]CommandHandler
+}
+
+// CommandHandler runs a single command. Implementations should be
+// idempotent where possible. Status transitions (RUNNING, COMPLETED,
+// FAILED) are recorded by the Manager via the WSClient and SQLite.
+type CommandHandler func(ctx context.Context, payload []byte) ([]byte, error)
+
+func NewManager(store *Store, baseURL, jwt, hostname, version string) *Manager {
+	return &Manager{
+		store:    store,
+		rest:     NewClient(baseURL, jwt),
+		hostname: hostname,
+		osName:   runtime.GOOS,
+		version:  version,
+		handlers: map[string]CommandHandler{},
+	}
+}
+
+// RegisterHandler binds a CommandHandler to a server command type.
+// Unhandled types are reported as failures back to the service.
+func (m *Manager) RegisterHandler(cmdType string, h CommandHandler) {
+	m.handlers[cmdType] = h
+}
+
+// Start performs the full bootstrap for the given profile: identity,
+// registration, and WebSocket attach.
+func (m *Manager) Start(ctx context.Context, profile string) error {
+	m.profile = profile
+
+	inst, err := m.store.GetOrCreateInstallation(func() string { return uuid.New().String() })
+	if err != nil {
+		return fmt.Errorf("cloud: get installation: %w", err)
+	}
+	m.inst = inst
+
+	reg, err := m.ensureRegistered(ctx)
+	if err != nil {
+		return err
+	}
+	m.reg = reg
+
+	m.wsCli = NewWSClient(WSClientConfig{
+		BaseRESTURL: m.rest.BaseURL,
+		WSURL:       reg.WSURL,
+		AgentId:     reg.AgentId,
+		AgentSecret: reg.AgentSecret,
+		Heartbeat:   time.Duration(reg.HeartbeatSec) * time.Second,
+		OnCommand:   m.handleCommand,
+		Dialer:      m.Dialer,
+		TokenSource: m.TokenSource,
+	})
+	return m.wsCli.Start(ctx)
+}
+
+// Stop tears down the WS connection. The local SQLite registration is
+// left intact so a later Start resumes the same agentId.
+func (m *Manager) Stop() {
+	if m.wsCli != nil {
+		m.wsCli.Stop()
+	}
+}
+
+func (m *Manager) AgentId() string { return m.reg.AgentId }
+
+// SendEvent emits an agent->server event over the WS.
+func (m *Manager) SendEvent(ctx context.Context, eventType string, payload []byte) error {
+	if m.wsCli == nil {
+		return fmt.Errorf("cloud: not connected")
+	}
+	return m.wsCli.Send(ctx, Envelope{
+		MessageId: uuid.New().String(),
+		Kind:      KindEvent,
+		Type:      eventType,
+		Payload:   payload,
+	})
+}
+
+func (m *Manager) ensureRegistered(ctx context.Context) (Registration, error) {
+	existing, err := m.store.GetRegistration(m.profile)
+	if err != nil && err != ErrNotFound {
+		return Registration{}, err
+	}
+
+	req := RegisterRequest{
+		InstallationId: m.inst.InstallationId,
+		Hostname:       m.hostname,
+		OS:             m.osName,
+		AgentVersion:   m.version,
+		ProfileName:    m.profile,
+	}
+	if existing.AgentId != "" {
+		req.AgentId = existing.AgentId
+	}
+
+	resp, err := m.rest.Register(ctx, req)
+	if err != nil {
+		return Registration{}, fmt.Errorf("cloud: register: %w", err)
+	}
+
+	reg := Registration{
+		ProfileName:  m.profile,
+		AgentId:      resp.AgentId,
+		AgentSecret:  existing.AgentSecret,
+		WSURL:        resp.WSURL,
+		WSTokenURL:   resp.WSTokenURL,
+		HeartbeatSec: resp.HeartbeatSec,
+		RegisteredAt: time.Now(),
+	}
+	// Server only returns the agent secret on first registration (or
+	// rotation) — preserve the previous value otherwise.
+	if resp.AgentSecret != "" {
+		reg.AgentSecret = resp.AgentSecret
+	}
+	if reg.AgentSecret == "" {
+		return Registration{}, fmt.Errorf("cloud: missing agent secret after registration")
+	}
+
+	if err := m.store.UpsertRegistration(reg); err != nil {
+		return Registration{}, fmt.Errorf("cloud: persist registration: %w", err)
+	}
+	return reg, nil
+}
+
+func (m *Manager) handleCommand(ctx context.Context, env Envelope) {
+	now := time.Now()
+
+	// Idempotency: skip if we have already seen this commandId.
+	seen, err := m.store.SeenCommand(env.MessageId)
+	if err == nil && seen {
+		_ = m.wsCli.Send(ctx, Envelope{
+			MessageId: env.MessageId,
+			Kind:      KindAck,
+			Payload:   marshalJSON(CommandAck{CommandId: env.MessageId}),
+		})
+		return
+	}
+
+	_ = m.store.UpsertCommand(LocalCommand{
+		CommandId:  env.MessageId,
+		Type:       env.Type,
+		Payload:    env.Payload,
+		Status:     CmdStatusReceived,
+		ReceivedAt: now,
+	})
+	_ = m.wsCli.Send(ctx, Envelope{
+		MessageId: env.MessageId,
+		Kind:      KindAck,
+		Payload:   marshalJSON(CommandAck{CommandId: env.MessageId}),
+	})
+
+	handler, ok := m.handlers[env.Type]
+	if !ok {
+		m.reportResult(ctx, env.MessageId, CmdStatusFailed, nil, "no handler registered for type "+env.Type)
+		return
+	}
+
+	started := time.Now()
+	_ = m.store.UpsertCommand(LocalCommand{
+		CommandId: env.MessageId,
+		Type:      env.Type,
+		Payload:   env.Payload,
+		Status:    CmdStatusRunning,
+		StartedAt: &started,
+	})
+
+	result, err := handler(ctx, env.Payload)
+	if err != nil {
+		m.reportResult(ctx, env.MessageId, CmdStatusFailed, nil, err.Error())
+		return
+	}
+	m.reportResult(ctx, env.MessageId, CmdStatusCompleted, result, "")
+}
+
+func (m *Manager) reportResult(ctx context.Context, commandId, status string, result []byte, errMsg string) {
+	completed := time.Now()
+	_ = m.store.UpsertCommand(LocalCommand{
+		CommandId:   commandId,
+		Status:      status,
+		CompletedAt: &completed,
+		Result:      result,
+		Error:       errMsg,
+	})
+	res := CommandResult{
+		CommandId: commandId,
+		Status:    status,
+		Result:    result,
+		Error:     errMsg,
+	}
+	_ = m.wsCli.Send(ctx, Envelope{
+		MessageId: commandId,
+		Kind:      KindResult,
+		Payload:   marshalJSON(res),
+	})
+}
+
+func marshalJSON(v any) []byte {
+	b, _ := jsonMarshal(v)
+	return b
+}

--- a/pkg/cloud/manager_test.go
+++ b/pkg/cloud/manager_test.go
@@ -1,0 +1,219 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRegistrar serves /agents/register and /agents/ws-token. It
+// records calls so tests can verify what the agent sent.
+type fakeRegistrar struct {
+	mu       sync.Mutex
+	registers []RegisterRequest
+	srv      *httptest.Server
+}
+
+func newFakeRegistrar(t *testing.T, agentId, secret string) *fakeRegistrar {
+	t.Helper()
+	r := &fakeRegistrar{}
+	r.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/agents/register":
+			var body RegisterRequest
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			r.mu.Lock()
+			r.registers = append(r.registers, body)
+			r.mu.Unlock()
+			resp := RegisterResponse{
+				AgentId: agentId, AgentSecret: secret, WSURL: "wss://x",
+				WSTokenURL: r.srv.URL + "/agents/ws-token", HeartbeatSec: 270,
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(r.srv.Close)
+	return r
+}
+
+func TestManager_StartRegistersAndPersists(t *testing.T) {
+	store := NewStore(newTestDB(t))
+	srv := newFakeRegistrar(t, "agent-1", "secret-1")
+
+	m := NewManager(store, srv.srv.URL, "JWT", "host", "v1.0")
+	m.Dialer = &stubDialer{conns: []WSConn{newFakeConn()}}
+	m.TokenSource = &stubTokenSource{token: "tok"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	require.NoError(t, m.Start(ctx, "default"))
+	t.Cleanup(m.Stop)
+
+	srv.mu.Lock()
+	require.Len(t, srv.registers, 1)
+	assert.Equal(t, "default", srv.registers[0].ProfileName)
+	assert.NotEmpty(t, srv.registers[0].InstallationId)
+	srv.mu.Unlock()
+
+	row, err := store.GetRegistration("default")
+	require.NoError(t, err)
+	assert.Equal(t, "agent-1", row.AgentId)
+	assert.Equal(t, "secret-1", row.AgentSecret)
+}
+
+func TestManager_StartReusesExistingRegistration(t *testing.T) {
+	store := NewStore(newTestDB(t))
+
+	// Pre-seed the store as if the agent has already registered.
+	require.NoError(t, store.UpsertRegistration(Registration{
+		ProfileName: "default", AgentId: "old-agent",
+		AgentSecret: "old-secret", WSURL: "wss://x",
+		WSTokenURL:   "https://x/token", HeartbeatSec: 270,
+		RegisteredAt: time.Now(),
+	}))
+
+	// Server returns the same agentId and an EMPTY agent secret —
+	// indicating "no rotation". Manager must keep the previously
+	// stored secret.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var body RegisterRequest
+		_ = json.NewDecoder(req.Body).Decode(&body)
+		assert.Equal(t, "old-agent", body.AgentId)
+		_ = json.NewEncoder(w).Encode(RegisterResponse{
+			AgentId: "old-agent", AgentSecret: "", WSURL: "wss://x", HeartbeatSec: 270,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	m := NewManager(store, srv.URL, "JWT", "host", "v1.0")
+	m.Dialer = &stubDialer{conns: []WSConn{newFakeConn()}}
+	m.TokenSource = &stubTokenSource{token: "tok"}
+	require.NoError(t, m.Start(context.Background(), "default"))
+	t.Cleanup(m.Stop)
+
+	row, _ := store.GetRegistration("default")
+	assert.Equal(t, "old-agent", row.AgentId)
+	assert.Equal(t, "old-secret", row.AgentSecret, "secret preserved when server doesn't rotate")
+}
+
+func TestManager_HandleCommand_RunsRegisteredHandler(t *testing.T) {
+	store := NewStore(newTestDB(t))
+
+	// We don't need a real REST server for this test — we drive
+	// handleCommand directly.
+	m := NewManager(store, "http://unused", "JWT", "host", "v1")
+	m.reg = Registration{ProfileName: "default", AgentId: "a1", AgentSecret: "s"}
+	m.inst = Installation{InstallationId: "inst-1"}
+
+	conn := newFakeConn()
+	m.wsCli = NewWSClient(WSClientConfig{
+		WSURL:       "wss://x",
+		Heartbeat:   time.Hour,
+		Dialer:      &stubDialer{conns: []WSConn{conn}},
+		TokenSource: &stubTokenSource{token: "tok"},
+	})
+	require.NoError(t, m.wsCli.Start(context.Background()))
+	t.Cleanup(m.wsCli.Stop)
+
+	called := make(chan []byte, 1)
+	m.RegisterHandler("ping", func(_ context.Context, payload []byte) ([]byte, error) {
+		called <- payload
+		return []byte(`{"pong":true}`), nil
+	})
+
+	env := Envelope{MessageId: "c1", Kind: KindCommand, Type: "ping", Payload: []byte(`{"x":1}`)}
+	go m.handleCommand(context.Background(), env)
+
+	select {
+	case p := <-called:
+		assert.JSONEq(t, `{"x":1}`, string(p))
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler not invoked")
+	}
+
+	// Wait for terminal status to be persisted.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		seen, _ := store.SeenCommand("c1")
+		if seen {
+			rows, _ := store.OutstandingCommands()
+			if len(rows) == 0 {
+				return // c1 is no longer outstanding -> COMPLETED
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("c1 never reached terminal state")
+}
+
+func TestManager_HandleCommand_IsIdempotent(t *testing.T) {
+	store := NewStore(newTestDB(t))
+	m := NewManager(store, "http://unused", "", "host", "v1")
+	m.reg = Registration{AgentId: "a1"}
+
+	conn := newFakeConn()
+	m.wsCli = NewWSClient(WSClientConfig{
+		WSURL: "wss://x", Heartbeat: time.Hour,
+		Dialer:      &stubDialer{conns: []WSConn{conn}},
+		TokenSource: &stubTokenSource{token: "tok"},
+	})
+	require.NoError(t, m.wsCli.Start(context.Background()))
+	t.Cleanup(m.wsCli.Stop)
+
+	calls := 0
+	m.RegisterHandler("ping", func(_ context.Context, _ []byte) ([]byte, error) {
+		calls++
+		return nil, nil
+	})
+
+	env := Envelope{MessageId: "c1", Kind: KindCommand, Type: "ping"}
+	m.handleCommand(context.Background(), env)
+	m.handleCommand(context.Background(), env)
+
+	// Drain in case work goroutines are still pending.
+	time.Sleep(50 * time.Millisecond)
+	assert.LessOrEqual(t, calls, 1, "second delivery of same commandId must be a no-op")
+}
+
+func TestManager_HandleCommand_NoHandlerReportsFailed(t *testing.T) {
+	store := NewStore(newTestDB(t))
+	m := NewManager(store, "http://unused", "", "host", "v1")
+	m.reg = Registration{AgentId: "a1"}
+	conn := newFakeConn()
+	m.wsCli = NewWSClient(WSClientConfig{
+		WSURL: "wss://x", Heartbeat: time.Hour,
+		Dialer:      &stubDialer{conns: []WSConn{conn}},
+		TokenSource: &stubTokenSource{token: "tok"},
+	})
+	require.NoError(t, m.wsCli.Start(context.Background()))
+	t.Cleanup(m.wsCli.Stop)
+
+	m.handleCommand(context.Background(), Envelope{MessageId: "c1", Kind: KindCommand, Type: "unknown"})
+
+	// Wait for the result envelope to be written.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		envs := conn.writtenEnvelopes()
+		for _, env := range envs {
+			if env.Kind == KindResult {
+				var res CommandResult
+				_ = json.Unmarshal(env.Payload, &res)
+				assert.Equal(t, "c1", res.CommandId)
+				assert.Equal(t, CmdStatusFailed, res.Status)
+				assert.Contains(t, res.Error, "no handler")
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("never received KindResult envelope")
+}

--- a/pkg/cloud/store.go
+++ b/pkg/cloud/store.go
@@ -1,0 +1,186 @@
+package cloud
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+)
+
+var ErrNotFound = errors.New("not found")
+
+// Installation is the host's local identity. Stable across restarts;
+// regenerated only if the SQLite database is wiped.
+type Installation struct {
+	InstallationId string
+	CreatedAt      time.Time
+}
+
+// Registration is per-profile. profileName matches the Viper profile
+// section in ~/.pennsieve/config.ini.
+type Registration struct {
+	ProfileName  string
+	AgentId      string
+	AgentSecret  string
+	WSURL        string
+	WSTokenURL   string
+	HeartbeatSec int
+	RegisteredAt time.Time
+}
+
+// LocalCommand mirrors the server-side command record so the agent can
+// recover state on restart and reconcile with the service.
+type LocalCommand struct {
+	CommandId   string
+	Type        string
+	Payload     []byte
+	Status      string
+	ReceivedAt  time.Time
+	StartedAt   *time.Time
+	CompletedAt *time.Time
+	Result      []byte
+	Error       string
+}
+
+type Store struct {
+	DB *sql.DB
+}
+
+func NewStore(db *sql.DB) *Store { return &Store{DB: db} }
+
+// GetOrCreateInstallation returns the local installation, creating it
+// (with a fresh UUID) on first call. Caller supplies the UUID factory
+// so tests can be deterministic.
+func (s *Store) GetOrCreateInstallation(newID func() string) (Installation, error) {
+	row := s.DB.QueryRow(`SELECT installation_id, created_at FROM cloud_installation LIMIT 1`)
+	var inst Installation
+	var ts int64
+	if err := row.Scan(&inst.InstallationId, &ts); err == nil {
+		inst.CreatedAt = time.Unix(ts, 0)
+		return inst, nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return Installation{}, err
+	}
+	id := newID()
+	now := time.Now().Unix()
+	if _, err := s.DB.Exec(`INSERT INTO cloud_installation (installation_id, created_at) VALUES (?, ?)`, id, now); err != nil {
+		return Installation{}, err
+	}
+	return Installation{InstallationId: id, CreatedAt: time.Unix(now, 0)}, nil
+}
+
+func (s *Store) GetRegistration(profile string) (Registration, error) {
+	row := s.DB.QueryRow(`
+		SELECT profile_name, agent_id, agent_secret, ws_url, ws_token_url, heartbeat_sec, registered_at
+		FROM cloud_registration WHERE profile_name = ?`, profile)
+	var r Registration
+	var ts int64
+	if err := row.Scan(&r.ProfileName, &r.AgentId, &r.AgentSecret, &r.WSURL, &r.WSTokenURL, &r.HeartbeatSec, &ts); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Registration{}, ErrNotFound
+		}
+		return Registration{}, err
+	}
+	r.RegisteredAt = time.Unix(ts, 0)
+	return r, nil
+}
+
+func (s *Store) UpsertRegistration(r Registration) error {
+	_, err := s.DB.Exec(`
+		INSERT INTO cloud_registration
+			(profile_name, agent_id, agent_secret, ws_url, ws_token_url, heartbeat_sec, registered_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(profile_name) DO UPDATE SET
+			agent_id      = excluded.agent_id,
+			agent_secret  = excluded.agent_secret,
+			ws_url        = excluded.ws_url,
+			ws_token_url  = excluded.ws_token_url,
+			heartbeat_sec = excluded.heartbeat_sec,
+			registered_at = excluded.registered_at`,
+		r.ProfileName, r.AgentId, r.AgentSecret, r.WSURL, r.WSTokenURL, r.HeartbeatSec, r.RegisteredAt.Unix())
+	return err
+}
+
+func (s *Store) UpsertCommand(c LocalCommand) error {
+	var startedAt, completedAt sql.NullInt64
+	if c.StartedAt != nil {
+		startedAt = sql.NullInt64{Int64: c.StartedAt.Unix(), Valid: true}
+	}
+	if c.CompletedAt != nil {
+		completedAt = sql.NullInt64{Int64: c.CompletedAt.Unix(), Valid: true}
+	}
+	// Payload is NOT NULL in the schema; coalesce nil to empty bytes
+	// so callers updating an existing command (without re-supplying
+	// the payload) don't trip the constraint on the INSERT side of
+	// the upsert.
+	payload := c.Payload
+	if payload == nil {
+		payload = []byte{}
+	}
+	_, err := s.DB.Exec(`
+		INSERT INTO cloud_command
+			(command_id, type, payload, status, received_at, started_at, completed_at, result, error)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(command_id) DO UPDATE SET
+			status       = excluded.status,
+			started_at   = COALESCE(excluded.started_at, cloud_command.started_at),
+			completed_at = COALESCE(excluded.completed_at, cloud_command.completed_at),
+			result       = COALESCE(excluded.result, cloud_command.result),
+			error        = excluded.error`,
+		c.CommandId, c.Type, payload, c.Status, c.ReceivedAt.Unix(),
+		startedAt, completedAt, c.Result, c.Error)
+	return err
+}
+
+// SeenCommand returns true if the agent has previously recorded this
+// commandId. Used for at-least-once idempotency: a second delivery of
+// the same command is a no-op.
+func (s *Store) SeenCommand(commandId string) (bool, error) {
+	row := s.DB.QueryRow(`SELECT 1 FROM cloud_command WHERE command_id = ?`, commandId)
+	var x int
+	err := row.Scan(&x)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+// OutstandingCommands returns commands that have not reached a terminal
+// state. Used for reconciliation on reconnect.
+func (s *Store) OutstandingCommands() ([]LocalCommand, error) {
+	rows, err := s.DB.Query(`
+		SELECT command_id, type, payload, status, received_at,
+		       started_at, completed_at, result, error
+		FROM cloud_command
+		WHERE status IN (?, ?)`,
+		CmdStatusReceived, CmdStatusRunning)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []LocalCommand
+	for rows.Next() {
+		var c LocalCommand
+		var receivedAt int64
+		var startedAt, completedAt sql.NullInt64
+		var errStr sql.NullString
+		if err := rows.Scan(&c.CommandId, &c.Type, &c.Payload, &c.Status, &receivedAt,
+			&startedAt, &completedAt, &c.Result, &errStr); err != nil {
+			return nil, err
+		}
+		c.ReceivedAt = time.Unix(receivedAt, 0)
+		if startedAt.Valid {
+			t := time.Unix(startedAt.Int64, 0)
+			c.StartedAt = &t
+		}
+		if completedAt.Valid {
+			t := time.Unix(completedAt.Int64, 0)
+			c.CompletedAt = &t
+		}
+		if errStr.Valid {
+			c.Error = errStr.String
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}

--- a/pkg/cloud/store_test.go
+++ b/pkg/cloud/store_test.go
@@ -1,0 +1,159 @@
+package cloud
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestDB returns a fresh in-memory SQLite database with the cloud
+// tables created. Each test gets its own DB so tests can run in
+// parallel without colliding on schema state.
+func newTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	schema := []string{
+		`CREATE TABLE cloud_installation (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			installation_id TEXT UNIQUE NOT NULL,
+			created_at INTEGER NOT NULL
+		)`,
+		`CREATE TABLE cloud_registration (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			profile_name TEXT UNIQUE NOT NULL,
+			agent_id TEXT NOT NULL,
+			agent_secret TEXT NOT NULL,
+			ws_url TEXT NOT NULL,
+			ws_token_url TEXT NOT NULL,
+			heartbeat_sec INTEGER NOT NULL DEFAULT 270,
+			registered_at INTEGER NOT NULL
+		)`,
+		`CREATE TABLE cloud_command (
+			command_id TEXT PRIMARY KEY,
+			type TEXT NOT NULL,
+			payload TEXT NOT NULL,
+			status TEXT NOT NULL,
+			received_at INTEGER NOT NULL,
+			started_at INTEGER,
+			completed_at INTEGER,
+			result TEXT,
+			error TEXT
+		)`,
+	}
+	for _, s := range schema {
+		_, err := db.Exec(s)
+		require.NoError(t, err)
+	}
+	return db
+}
+
+func TestStore_Installation_GetOrCreateIsStable(t *testing.T) {
+	s := NewStore(newTestDB(t))
+	first, err := s.GetOrCreateInstallation(func() string { return "id-1" })
+	require.NoError(t, err)
+	assert.Equal(t, "id-1", first.InstallationId)
+
+	// Second call returns the same row even if the factory would have
+	// produced a different id.
+	second, err := s.GetOrCreateInstallation(func() string { return "id-2" })
+	require.NoError(t, err)
+	assert.Equal(t, "id-1", second.InstallationId)
+}
+
+func TestStore_Registration_UpsertAndGet(t *testing.T) {
+	s := NewStore(newTestDB(t))
+	r := Registration{
+		ProfileName:  "default",
+		AgentId:      "a1",
+		AgentSecret:  "s1",
+		WSURL:        "wss://example",
+		WSTokenURL:   "https://example/token",
+		HeartbeatSec: 200,
+		RegisteredAt: time.Unix(1700000000, 0),
+	}
+	require.NoError(t, s.UpsertRegistration(r))
+
+	got, err := s.GetRegistration("default")
+	require.NoError(t, err)
+	assert.Equal(t, r.AgentId, got.AgentId)
+	assert.Equal(t, r.AgentSecret, got.AgentSecret)
+
+	// Upsert overwrites.
+	r.AgentSecret = "s2"
+	require.NoError(t, s.UpsertRegistration(r))
+	got, _ = s.GetRegistration("default")
+	assert.Equal(t, "s2", got.AgentSecret)
+}
+
+func TestStore_Registration_NotFound(t *testing.T) {
+	s := NewStore(newTestDB(t))
+	_, err := s.GetRegistration("missing")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStore_Command_UpsertAndSeen(t *testing.T) {
+	s := NewStore(newTestDB(t))
+	now := time.Now()
+	require.NoError(t, s.UpsertCommand(LocalCommand{
+		CommandId:  "c1",
+		Type:       "ping",
+		Payload:    []byte(`{"x":1}`),
+		Status:     CmdStatusReceived,
+		ReceivedAt: now,
+	}))
+	seen, err := s.SeenCommand("c1")
+	require.NoError(t, err)
+	assert.True(t, seen)
+
+	miss, err := s.SeenCommand("never")
+	require.NoError(t, err)
+	assert.False(t, miss)
+
+	// Upserting with RUNNING preserves received_at and merges started_at.
+	started := now.Add(time.Second)
+	require.NoError(t, s.UpsertCommand(LocalCommand{
+		CommandId: "c1",
+		Type:      "ping",
+		Payload:   []byte(`{"x":1}`),
+		Status:    CmdStatusRunning,
+		StartedAt: &started,
+	}))
+}
+
+func TestStore_OutstandingCommands(t *testing.T) {
+	s := NewStore(newTestDB(t))
+	now := time.Now()
+
+	cases := []struct {
+		id, status string
+	}{
+		{"c-recv", CmdStatusReceived},
+		{"c-run", CmdStatusRunning},
+		{"c-done", CmdStatusCompleted},
+		{"c-fail", CmdStatusFailed},
+	}
+	for _, c := range cases {
+		require.NoError(t, s.UpsertCommand(LocalCommand{
+			CommandId: c.id, Type: "x", Payload: []byte("{}"),
+			Status: c.status, ReceivedAt: now,
+		}))
+	}
+
+	out, err := s.OutstandingCommands()
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, c := range out {
+		ids[c.CommandId] = true
+	}
+	assert.True(t, ids["c-recv"])
+	assert.True(t, ids["c-run"])
+	assert.False(t, ids["c-done"])
+	assert.False(t, ids["c-fail"])
+}

--- a/pkg/cloud/types.go
+++ b/pkg/cloud/types.go
@@ -1,0 +1,67 @@
+package cloud
+
+import "encoding/json"
+
+// Wire envelope shared with pennsieve-agent-service. Keep this in sync
+// with internal/models/wire.go in the service repo.
+type Envelope struct {
+	MessageId string          `json:"id"`
+	Kind      string          `json:"kind"`
+	Type      string          `json:"type,omitempty"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+}
+
+const (
+	KindEvent     = "event"
+	KindCommand   = "command"
+	KindAck       = "ack"
+	KindResult    = "result"
+	KindHeartbeat = "heartbeat"
+	KindReconcile = "reconcile"
+)
+
+const (
+	CmdStatusReceived  = "DELIVERED"
+	CmdStatusRunning   = "RUNNING"
+	CmdStatusCompleted = "COMPLETED"
+	CmdStatusFailed    = "FAILED"
+)
+
+type CommandAck struct {
+	CommandId string `json:"commandId"`
+}
+
+type CommandResult struct {
+	CommandId string          `json:"commandId"`
+	Status    string          `json:"status"`
+	Result    json.RawMessage `json:"result,omitempty"`
+	Error     string          `json:"error,omitempty"`
+}
+
+// REST DTOs (mirror service models).
+type RegisterRequest struct {
+	InstallationId string `json:"installationId"`
+	AgentId        string `json:"agentId,omitempty"`
+	Hostname       string `json:"hostname"`
+	OS             string `json:"os"`
+	AgentVersion   string `json:"agentVersion"`
+	ProfileName    string `json:"profileName"`
+}
+
+type RegisterResponse struct {
+	AgentId      string `json:"agentId"`
+	AgentSecret  string `json:"agentSecret,omitempty"`
+	WSURL        string `json:"wsUrl"`
+	WSTokenURL   string `json:"wsTokenUrl"`
+	HeartbeatSec int    `json:"heartbeatSec"`
+}
+
+type WSTokenRequest struct {
+	AgentId     string `json:"agentId"`
+	AgentSecret string `json:"agentSecret"`
+}
+
+type WSTokenResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expiresAt"`
+}

--- a/pkg/cloud/ws.go
+++ b/pkg/cloud/ws.go
@@ -1,0 +1,245 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// WSConn abstracts the underlying WebSocket implementation. The
+// production implementation wraps coder/websocket; tests provide a
+// fake. Methods are expected to be safe for concurrent use by separate
+// reader/writer goroutines (one Read at a time, one Write at a time).
+type WSConn interface {
+	Read(ctx context.Context) ([]byte, error)
+	Write(ctx context.Context, data []byte) error
+	Close() error
+}
+
+// Dialer dials the given ws url with the given short-lived token.
+type Dialer interface {
+	Dial(ctx context.Context, wsURL, token string) (WSConn, error)
+}
+
+// TokenSource exchanges the long-lived agentSecret for a short-lived
+// ws token. In production this calls the REST /agents/ws-token; tests
+// stub it with a static token.
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// CommandCallback is invoked for every inbound Kind=command envelope.
+type CommandCallback func(ctx context.Context, env Envelope)
+
+// WSClientConfig configures a WSClient. Defaults are set in
+// NewWSClient if zero values are present.
+type WSClientConfig struct {
+	BaseRESTURL string
+	WSURL       string
+	AgentId     string
+	AgentSecret string
+	Heartbeat   time.Duration
+	OnCommand   CommandCallback
+
+	// Optional overrides — used by tests.
+	Dialer      Dialer
+	TokenSource TokenSource
+}
+
+// WSClient maintains a single WebSocket connection. On disconnect it
+// reconnects with exponential backoff. Outbound writes are serialized
+// through a single goroutine; inbound reads are dispatched to
+// OnCommand for command envelopes and dropped for everything else.
+type WSClient struct {
+	cfg WSClientConfig
+
+	dialer      Dialer
+	tokenSource TokenSource
+
+	mu       sync.Mutex
+	conn     WSConn
+	stopChan chan struct{}
+	stopped  bool
+
+	send chan Envelope
+}
+
+func NewWSClient(cfg WSClientConfig) *WSClient {
+	if cfg.Heartbeat == 0 {
+		cfg.Heartbeat = 270 * time.Second
+	}
+	w := &WSClient{
+		cfg:      cfg,
+		stopChan: make(chan struct{}),
+		send:     make(chan Envelope, 32),
+	}
+	w.dialer = cfg.Dialer
+	if w.dialer == nil {
+		w.dialer = defaultDialer{}
+	}
+	w.tokenSource = cfg.TokenSource
+	if w.tokenSource == nil {
+		w.tokenSource = &restTokenSource{
+			client:      NewClient(cfg.BaseRESTURL, ""),
+			agentId:     cfg.AgentId,
+			agentSecret: cfg.AgentSecret,
+		}
+	}
+	return w
+}
+
+// Start launches the connect/reconnect loop. Returns immediately.
+func (w *WSClient) Start(ctx context.Context) error {
+	go w.run(ctx)
+	return nil
+}
+
+func (w *WSClient) Stop() {
+	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		return
+	}
+	w.stopped = true
+	close(w.stopChan)
+	if w.conn != nil {
+		_ = w.conn.Close()
+	}
+	w.mu.Unlock()
+}
+
+// Send enqueues an envelope for delivery on the next available
+// connection. Caller is responsible for setting MessageId / Kind / etc.
+func (w *WSClient) Send(ctx context.Context, env Envelope) error {
+	select {
+	case w.send <- env:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-w.stopChan:
+		return fmt.Errorf("ws client stopped")
+	}
+}
+
+func (w *WSClient) run(ctx context.Context) {
+	backoff := time.Second
+	for {
+		select {
+		case <-w.stopChan:
+			return
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		token, err := w.tokenSource.Token(ctx)
+		if err != nil {
+			waitOrStop(w.stopChan, backoff)
+			backoff = nextBackoff(backoff)
+			continue
+		}
+		conn, err := w.dialer.Dial(ctx, w.cfg.WSURL, token)
+		if err != nil {
+			waitOrStop(w.stopChan, backoff)
+			backoff = nextBackoff(backoff)
+			continue
+		}
+		backoff = time.Second
+
+		w.mu.Lock()
+		w.conn = conn
+		w.mu.Unlock()
+
+		w.serve(ctx, conn)
+
+		_ = conn.Close()
+		w.mu.Lock()
+		w.conn = nil
+		w.mu.Unlock()
+	}
+}
+
+func (w *WSClient) serve(ctx context.Context, conn WSConn) {
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		for {
+			b, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+			var env Envelope
+			if err := json.Unmarshal(b, &env); err != nil {
+				continue
+			}
+			if env.Kind == KindCommand && w.cfg.OnCommand != nil {
+				w.cfg.OnCommand(ctx, env)
+			}
+		}
+	}()
+
+	heartbeat := time.NewTicker(w.cfg.Heartbeat)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-w.stopChan:
+			return
+		case <-ctx.Done():
+			return
+		case <-readDone:
+			return
+		case env := <-w.send:
+			b, err := json.Marshal(env)
+			if err != nil {
+				continue
+			}
+			if err := conn.Write(ctx, b); err != nil {
+				return
+			}
+		case <-heartbeat.C:
+			b, _ := json.Marshal(Envelope{Kind: KindHeartbeat})
+			if err := conn.Write(ctx, b); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func waitOrStop(stop <-chan struct{}, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-stop:
+	case <-t.C:
+	}
+}
+
+func nextBackoff(cur time.Duration) time.Duration {
+	next := cur * 2
+	if next > 60*time.Second {
+		next = 60 * time.Second
+	}
+	return next
+}
+
+// restTokenSource is the production TokenSource — exchanges
+// agentSecret for a fresh ws token via /agents/ws-token.
+type restTokenSource struct {
+	client      *Client
+	agentId     string
+	agentSecret string
+}
+
+func (r *restTokenSource) Token(ctx context.Context) (string, error) {
+	resp, err := r.client.WSToken(ctx, WSTokenRequest{
+		AgentId:     r.agentId,
+		AgentSecret: r.agentSecret,
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Token, nil
+}

--- a/pkg/cloud/ws_test.go
+++ b/pkg/cloud/ws_test.go
@@ -1,0 +1,212 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeConn is an in-memory WSConn used by tests. Reads pop from a
+// channel; writes append to a buffer guarded by a mutex.
+type fakeConn struct {
+	reads     chan []byte
+	closeOnce sync.Once
+	closed    chan struct{}
+
+	mu     sync.Mutex
+	writes [][]byte
+}
+
+func newFakeConn() *fakeConn {
+	return &fakeConn{
+		reads:  make(chan []byte, 16),
+		closed: make(chan struct{}),
+	}
+}
+
+func (c *fakeConn) Read(ctx context.Context) ([]byte, error) {
+	select {
+	case b, ok := <-c.reads:
+		if !ok {
+			return nil, io.EOF
+		}
+		return b, nil
+	case <-c.closed:
+		return nil, io.EOF
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (c *fakeConn) Write(_ context.Context, data []byte) error {
+	select {
+	case <-c.closed:
+		return io.ErrClosedPipe
+	default:
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writes = append(c.writes, append([]byte(nil), data...))
+	return nil
+}
+
+func (c *fakeConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return nil
+}
+
+func (c *fakeConn) deliver(b []byte) {
+	select {
+	case c.reads <- b:
+	case <-c.closed:
+	}
+}
+
+func (c *fakeConn) writtenEnvelopes() []Envelope {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Envelope, 0, len(c.writes))
+	for _, w := range c.writes {
+		var env Envelope
+		if err := json.Unmarshal(w, &env); err == nil {
+			out = append(out, env)
+		}
+	}
+	return out
+}
+
+// stubDialer / stubTokenSource used to drive the WS client without a
+// real network.
+
+type stubDialer struct {
+	conns []WSConn
+	idx   int
+	err   error
+	mu    sync.Mutex
+}
+
+func (s *stubDialer) Dial(_ context.Context, _, _ string) (WSConn, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.idx >= len(s.conns) {
+		return nil, errors.New("stubDialer: no more connections")
+	}
+	c := s.conns[s.idx]
+	s.idx++
+	return c, nil
+}
+
+type stubTokenSource struct {
+	token string
+	err   error
+}
+
+func (s *stubTokenSource) Token(_ context.Context) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.token, nil
+}
+
+func TestWSClient_DispatchesCommandToCallback(t *testing.T) {
+	conn := newFakeConn()
+	received := make(chan Envelope, 1)
+
+	cli := NewWSClient(WSClientConfig{
+		WSURL:     "wss://x",
+		Heartbeat: time.Hour, // disable for this test
+		Dialer:    &stubDialer{conns: []WSConn{conn}},
+		TokenSource: &stubTokenSource{token: "tok"},
+		OnCommand: func(_ context.Context, env Envelope) {
+			received <- env
+		},
+	})
+	require.NoError(t, cli.Start(context.Background()))
+	t.Cleanup(cli.Stop)
+
+	cmd, _ := json.Marshal(Envelope{MessageId: "c1", Kind: KindCommand, Type: "ping"})
+	conn.deliver(cmd)
+
+	select {
+	case env := <-received:
+		assert.Equal(t, "c1", env.MessageId)
+		assert.Equal(t, "ping", env.Type)
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnCommand not invoked")
+	}
+}
+
+func TestWSClient_SendIsWritten(t *testing.T) {
+	conn := newFakeConn()
+	cli := NewWSClient(WSClientConfig{
+		WSURL:       "wss://x",
+		Heartbeat:   time.Hour,
+		Dialer:      &stubDialer{conns: []WSConn{conn}},
+		TokenSource: &stubTokenSource{token: "tok"},
+	})
+	require.NoError(t, cli.Start(context.Background()))
+	t.Cleanup(cli.Stop)
+
+	require.NoError(t, cli.Send(context.Background(), Envelope{
+		MessageId: "ev-1", Kind: KindEvent, Type: "x",
+	}))
+
+	// Wait briefly for the write to land.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(conn.writtenEnvelopes()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	envs := conn.writtenEnvelopes()
+	require.NotEmpty(t, envs)
+	assert.Equal(t, "ev-1", envs[0].MessageId)
+}
+
+func TestWSClient_ReconnectsAfterDial(t *testing.T) {
+	c1 := newFakeConn()
+	c2 := newFakeConn()
+	dialer := &stubDialer{conns: []WSConn{c1, c2}}
+	cli := NewWSClient(WSClientConfig{
+		WSURL:       "wss://x",
+		Heartbeat:   time.Hour,
+		Dialer:      dialer,
+		TokenSource: &stubTokenSource{token: "tok"},
+	})
+	require.NoError(t, cli.Start(context.Background()))
+	t.Cleanup(cli.Stop)
+
+	// Wait for first dial to take effect, then close it to force a
+	// reconnect.
+	deadline := time.Now().Add(2 * time.Second)
+	for dialer.idx < 1 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	_ = c1.Close()
+
+	// Verify the dialer was called a second time.
+	deadline = time.Now().Add(3 * time.Second)
+	for dialer.idx < 2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.GreaterOrEqual(t, dialer.idx, 2, "client must redial after disconnect")
+}
+
+func TestNextBackoff_Caps(t *testing.T) {
+	cur := time.Second
+	for range 10 {
+		cur = nextBackoff(cur)
+	}
+	assert.LessOrEqual(t, cur, 60*time.Second)
+}


### PR DESCRIPTION
## Summary

Adds a new `pkg/cloud` package and SQLite migration so the agent can register itself with the cloud control plane (`pennsieve-agent-service`) and maintain a bi-directional WebSocket.

- `Manager` orchestrates first-time and repeat registration per Pennsieve profile, persists `installationId` (host) and `agentId` (server-issued)
- `WSClient` maintains a single connection with reconnect + heartbeat; `WSConn` / `Dialer` / `TokenSource` interfaces keep the package network-free for tests
- `Store` persists registration and command-lifecycle state in SQLite (new migration `000003_create_cloud_tables`)
- Inbound commands are idempotent: a `seen-commandId` lookup short-circuits replays
- Two-phase ack: agent sends `KindAck` on receipt and `KindResult` on completion
- `Manager.RegisterHandler(type, fn)` lets the rest of the agent bind command handlers

## Companion change

The cloud service is in `Pennsieve/pennsieve-agent-service` on branch `initial-implementation` (PR #1).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/cloud/...` — all cases pass (in-memory SQLite + httptest + fake WSConn)
- [ ] Plug in a real WebSocket Dialer (recommended: `github.com/coder/websocket`) and verify against a deployed `pennsieve-agent-service`
- [ ] Wire `cloud.Manager.Start` into `pkg/container.StartAgent` so the cloud connection comes up alongside the local gRPC server
- [ ] Define an initial command-type registry (e.g. `agent.ping`, `agent.cancelUpload`)

## Notes for review

- This change does NOT yet wire the cloud manager into agent startup — that's a deliberate follow-up so this PR is scoped to "introduce the package + persistence."
- The default WebSocket dialer (`pkg/cloud/dialer.go`) is a placeholder that returns an error if used; production code will inject a real `Dialer` via `Manager.Dialer`.
- Migration is up/down only; the existing migrate runner picks it up automatically via the `embed.FS` in `main.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)