### PR TITLE
fix upload.go to re-read the config.ini for each upload so changes to…

### DIFF
--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -202,6 +202,10 @@ func (s *agentServer) uploadProcessor(
 	syncDone <-chan struct{},
 	onConflict string,
 ) {
+	// Re-read config so changes to config.ini take effect without restarting the daemon.
+	// viper.Set values (e.g. from PENNSIEVE_AGENT_UPLOAD_WORKERS at daemon start) still
+	// take precedence over config-file values — their priority is unaffected by ReadInConfig.
+	_ = viper.ReadInConfig()
 	uploadWorkers := viper.GetInt("agent.upload_workers")
 	chunkSize := viper.GetInt64("agent.upload_chunk_size")
 


### PR DESCRIPTION
Issue: Expected behaviour:
You set PENNSIEVE_AGENT_UPLOAD_WORKERS to N, and you upload N files at a time.

Seen behaviour:
Agent uploads it's default number of files regardless of flag status

in config.ini

Fix: Call `viper.ReadInConfig()` at the start of `uploadProcessor` so the daemon picks up the current `config.ini` value on each upload without requiring a restart. `viper.Set` values (e.g. from env vars at daemon startup) retain highest priority and are unaffected.