### PR TITLE
fix(server): use fmt.Print for non-constant format strings

### DIFF
--- a/pkg/server/workflow.go
+++ b/pkg/server/workflow.go
@@ -205,7 +205,7 @@ func createInputCSV(workOrder *WorkOrder, listFilesResponse *api.ListManifestFil
 	f, err := os.Create(workOrder.FilePath + "/workflow/input.csv")
 	if err != nil {
 		errString = "Unable to create file"
-		fmt.Printf(errString)
+		fmt.Print(errString)
 		return err, errString
 	}
 	workOrder.Files = f.Name()
@@ -214,14 +214,14 @@ func createInputCSV(workOrder *WorkOrder, listFilesResponse *api.ListManifestFil
 	err = w.Write(record)
 	if err != nil {
 		errString = "Unable to write header"
-		fmt.Printf(errString)
+		fmt.Print(errString)
 		return err, errString
 	}
 	for _, file := range listFilesResponse.File {
 		record := []string{strconv.Itoa(int(file.Id)), file.SourcePath, file.TargetPath}
 		if err := w.Write(record); err != nil {
 			errString = fmt.Sprintf("error writing record to file: %v", err)
-			fmt.Printf(errString)
+			fmt.Print(errString)
 			return err, errString
 		}
 	}
@@ -229,7 +229,7 @@ func createInputCSV(workOrder *WorkOrder, listFilesResponse *api.ListManifestFil
 	err = f.Close()
 	if err != nil {
 		errString = fmt.Sprintf("Error closing file Stream: %v", err)
-		fmt.Printf(errString)
+		fmt.Print(errString)
 		return err, errString
 	}
 	return err, errString


### PR DESCRIPTION
## Why

Go 1.24's `vet` (run automatically by `go test ./...`) treats a non-constant format string in `fmt.Printf` as an error. `pkg/server/workflow.go` has four `fmt.Printf(errString)` calls, causing `pkg/server` to fail to build under the newer toolchain:

```
pkg/server/workflow.go:208,217,224,232: non-constant format string in call to fmt.Printf
[build failed]
```

This blocks CI on unrelated PRs (e.g. the Dependabot grpc bump #77).

## Change

These calls just print a plain string, so switch `fmt.Printf(errString)` → `fmt.Print(errString)`. No behavior change.

Verified with `go vet ./...` and `go test ./...` under go1.24 — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)