### PR TITLE
ci: bump Go to 1.24 in release and build workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.23.7
+        go-version: 1.24.0
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Go Tidy
         run: go mod tidy && git diff --exit-code
       - name: Go Mod
@@ -180,7 +180,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Build release
         id: build-release
         run: |
@@ -247,7 +247,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Build release
         id: build-release
         run: |
@@ -366,7 +366,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Build release
         id: build-release
         run: |


### PR DESCRIPTION
## Why

#89 raised the `go` directive to **1.24**, but `publish-release.yml` and `go.yml` still pinned Go **1.23**. The build CI passed only because `GOTOOLCHAIN=auto` silently downloads 1.24 to satisfy go.mod.

That implicit behavior is risky in the release pipeline: `publish-release.yml` runs `create-release` as its own job and publishes a **non-draft** GitHub release immediately, in parallel with the build/package jobs. If a build job tripped on the toolchain, we'd be left with a published release missing assets — requiring a delete + tag delete + retag (the cycle that bit the v2 launch).

## Change

- `publish-release.yml`: `go-version` **1.23 → 1.24** (linux, windows, mac-arm64, mac-x86_64 jobs)
- `go.yml`: `go-version` **1.23.7 → 1.24.0**

Makes the release/build toolchain explicit and matches the go.mod directive. Must merge **before** cutting the v2.0.4 release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)