### PR TITLE
fix(docker): bump build image to golang:1.24-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.23.7-alpine3.20
+FROM golang:1.24-alpine3.20
 WORKDIR /go/src/github.com/pennsieve/pennsieve-agent/
 COPY go.mod .
 COPY go.sum .


### PR DESCRIPTION
## Why

The `docker-release` job in `publish-release.yml` builds from this `Dockerfile`, which pinned `golang:1.23.7-alpine3.20`. The golang **alpine** images set `GOTOOLCHAIN=local`, so `go` refuses the `go 1.24.0` directive instead of auto-downloading the toolchain. This failed `docker-release` for the v2.0.4 release, while the `setup-go`-based jobs (which default to `GOTOOLCHAIN=auto`) succeeded.

This is the same class of latent version-boundary assumption as the workflow `go-version` pins (#90) and go-core's `Dockerfile.test` — just in a third spot the audit missed because this Dockerfile carries its own Go pin.

## Change
`FROM golang:1.23.7-alpine3.20` → `golang:1.24-alpine3.20`. Verified the image builds locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)